### PR TITLE
Added the ability to ignore messages from active window

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -45,7 +45,11 @@ sub print_text {
     my ($dest, $text, $stripped) = @_;
 
     my $opt = MSGLEVEL_HILIGHT|MSGLEVEL_MSGS;
-    if(($dest->{level} & ($opt)) && (($dest->{level} & MSGLEVEL_NOHILIGHT) == 0) && (!Irssi::settings_get_bool("irssinotifier_away_only") || $lastServer->{usermode_away} )) {
+    if (
+        ($dest->{level} & ($opt)) && (($dest->{level} & MSGLEVEL_NOHILIGHT) == 0) &&
+        (!Irssi::settings_get_bool("irssinotifier_away_only") || $lastServer->{usermode_away}) &&
+        (!Irssi::settings_get_bool("irssinotifier_ignore_active_window") || ($dest->{window}->{refnum} != (Irssi::active_win()->{refnum})))
+    ) {
         hilite();
     }
 }
@@ -108,6 +112,7 @@ sub decrypt {
 Irssi::settings_add_str('IrssiNotifier', 'irssinotifier_encryption_password', 'password');
 Irssi::settings_add_str('IrssiNotifier', 'irssinotifier_api_token', '');
 Irssi::settings_add_bool('IrssiNotifier', 'irssinotifier_away_only', false);
+Irssi::settings_add_bool('IrssiNotifier', 'irssinotifier_ignore_active_window', false);
 
 Irssi::signal_add('message public', 'public');
 Irssi::signal_add('message private', 'private');


### PR DESCRIPTION
Defaults to off. I really wanted the option to disable the spamming of my ongoing slow-paced private chats to my phone :)

Of course this has the danger of preventing notifications if Irssi is left idling at the window you would want notifications from, but hey it's optional...

Now what I really wanted was ignore_until_away_seconds -type of feature with actual idle-times (last user/screen/shell/term activity, not last irc-activity) but I didn't find bindings to such data.
