### PR TITLE
Added feature for preventing notifications until keyboard idle of given ...

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -23,7 +23,7 @@ my $lastNick;
 my $lastAddress;
 my $lastTarget;
 
-my $lastActivity = time;
+my $lastKeyboardActivity = time;
 
 sub private {
     my ($server, $msg, $nick, $address) = @_;
@@ -58,7 +58,7 @@ sub print_text {
 
 sub activity_allows_hilight {
     my $timeout = Irssi::settings_get_int('irssinotifier_require_idle_seconds');
-    return ($timeout <= 0 || (time - $lastActivity) > $timeout);
+    return ($timeout <= 0 || (time - $lastKeyboardActivity) > $timeout);
 }
 
 sub hilite {
@@ -124,7 +124,7 @@ sub setup_keypress_handler {
 }
 
 sub event_key_pressed {
-    $lastActivity = time;
+    $lastKeyboardActivity = time;
 }
 
 Irssi::settings_add_str('IrssiNotifier', 'irssinotifier_encryption_password', 'password');


### PR DESCRIPTION
Adds setting irssinotifier_require_idle_seconds which defaults to 0, meaning timeout is not checked. If positive value is provided, notifications are sent only if keyboard idle seconds exceeds the given value. Uses keypress listener only if timeout value is set ( > 0).

This differs from using auto-away and irssinotifier_away_only since this can be set to relatively small value, mainly to prevent active chatting from spamming your phone.
