### PR TITLE
wget retry and timeout changes

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -119,7 +119,7 @@ sub send_notification {
     $lastTarget = encrypt($lastTarget);
 
     my $data = "--post-data=apiToken=$api_token\\&message=$lastMsg\\&channel=$lastTarget\\&nick=$lastNick\\&version=$VERSION";
-    my $result = `wget --no-check-certificate -qO- /dev/null $data https://irssinotifier.appspot.com/API/Message`;
+    my $result = `wget --tries=1 --timeout=10 --no-check-certificate -qO- /dev/null $data https://irssinotifier.appspot.com/API/Message`;
     if ($? != 0) {
         # Something went wrong, might be network error or authorization issue. Probably no need to alert user, though.
         # Irssi::print("IrssiNotifier: Sending hilight to server failed, check http://irssinotifier.appspot.com for updates");


### PR DESCRIPTION
remove retries for wget and set a sane timeout

wget will attempt multiple times to fetch a request. during the outage on 2012-10-26, this was a bad thing as it a) froze my irssi session during these hanging requests and b) resulted in multiple notifications for the same hilight.

10 seconds seems sane to try and deliver the message though there's probably better handling that could be done.  this at least prevents irssi from timing out.

thanks.
