### PR TITLE
Add support for some more highlighting options (nick blacklist, pattern blacklist and "whitelist")

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -115,10 +115,11 @@ sub should_send_notification {
         }
     }
 
-    # If specified, require a pattern to be matched before highlighting
-    my $required_highlight_pattern_string = Irssi::settings_get_str("irssinotifier_required_highlight_patterns");
-    if ($required_highlight_pattern_string ne '') {
-        my @required_patterns = split(/ /, $required_highlight_pattern_string);
+    # If specified, require a pattern to be matched before highlighting public
+    # messages
+    my $required_public_highlight_pattern_string = Irssi::settings_get_str("irssinotifier_required_public_highlight_patterns");
+    if ($required_public_highlight_pattern_string ne '' && ($dest->{level} & MSGLEVEL_PUBLIC)) {
+        my @required_patterns = split(/ /, $required_public_highlight_pattern_string);
         if (!(grep { $lastMsg =~ /$_/i } @required_patterns)) {
             return 0; # Required pattern not matched
         }
@@ -234,7 +235,7 @@ Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_servers', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_channels', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_nicks', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_highlight_patterns', '');
-Irssi::settings_add_str('irssinotifier', 'irssinotifier_required_highlight_patterns', '');
+Irssi::settings_add_str('irssinotifier', 'irssinotifier_required_public_highlight_patterns', '');
 Irssi::settings_add_bool('irssinotifier', 'irssinotifier_ignore_active_window', 0);
 Irssi::settings_add_bool('irssinotifier', 'irssinotifier_away_only', 0);
 Irssi::settings_add_int('irssinotifier', 'irssinotifier_require_idle_seconds', 0);


### PR DESCRIPTION
I've added three new highlight-control options to my version of irssinotifier.pl; these are:
- `irssinotifier_ignored_nicks` - a list of nicks to block highlights from (if set). Useful for ignoring highlights from bots.
- `irssinotifier_ignored_highlight_patterns` - a list of regular expressions; if set, if the message matches any of these, then the highlight will not be sent. Useful for ignoring automated messages that you don't care about.
- `irssinotifier_required_highlight_patterns` - a list of regular expressions; if set, the message must match at least one of these in order for a highlight to be sent. Useful for if you have a lot of highlights in irssi but don't want to be notified for most of them.

(I've also got rid of a few stray tabs and replaced them with spaces.)

-Dave
