### PR TITLE
added https_proxy support for wget

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -52,7 +52,7 @@ sub public {
 
 sub print_text {
     my ($dest, $text, $stripped) = @_;
-    
+
     if (should_send_notification($dest))
     {
         send_notification();
@@ -141,7 +141,7 @@ sub should_send_notification {
     if ($timeout > 0 && (time - $lastKeyboardActivity) <= $timeout) {
         return 0; # not enough idle seconds
     }
-    
+
     return 1;
 }
 
@@ -184,11 +184,16 @@ sub send_notification {
     } else {
       eval {
         my $api_token = Irssi::settings_get_str('irssinotifier_api_token');
-    
+        my $proxy     = Irssi::settings_get_str('irssinotifier_https_proxy');
+
         my $encryption_password = Irssi::settings_get_str('irssinotifier_encryption_password');
         $lastMsg    = encrypt(Encode::encode_utf8(Irssi::strip_codes($lastMsg)));
         $lastNick   = encrypt(Encode::encode_utf8($lastNick));
         $lastTarget = encrypt(Encode::encode_utf8($lastTarget));
+
+        if($proxy) {
+            $ENV{https_proxy} = $proxy;
+        }
 
         my $data = "--post-data=apiToken=$api_token\\&message=$lastMsg\\&channel=$lastTarget\\&nick=$lastNick\\&version=$VERSION";
         my $result = `wget --tries=1 --timeout=5 --no-check-certificate -qO- /dev/null $data https://irssinotifier.appspot.com/API/Message`;
@@ -240,7 +245,7 @@ sub read_pipe {
 
 sub encrypt {
     my ($text) = @_ ? shift : $_;
-    
+
     local $ENV{PASS} = Irssi::settings_get_str('irssinotifier_encryption_password');
     my $pid = open2 my $out, my $in, qw(
         openssl enc -aes-128-cbc -salt -base64 -A -pass env:PASS
@@ -336,6 +341,7 @@ if ($screen_ls !~ /^No Sockets found/s) {
 
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_encryption_password', 'password');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_api_token', '');
+Irssi::settings_add_str('irssinotifier', 'irssinotifier_https_proxy', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_servers', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_channels', '');
 Irssi::settings_add_str('irssinotifier', 'irssinotifier_ignored_nicks', '');


### PR DESCRIPTION
Set the https_proxy environment variable before calling wget. I tested with polipo and simple tcpdump, and worked fine on my setup.
