### PR TITLE
Fix mixed content warning when viewing index.html over HTTPS

### DIFF
--- a/Server/IrssiNotifierServer/html/index.html
+++ b/Server/IrssiNotifierServer/html/index.html
@@ -199,7 +199,7 @@
         </form>
 
         <a href="http://flattr.com/thing/628213/IrssiNotifier" target="_blank" >
-            <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" style="margin-top: 2px;"/>
+            <img src="https://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" style="margin-top: 2px;"/>
         </a>
 
         </div>


### PR DESCRIPTION
You're currently including an image that's loaded over HTTP, so I changed the link to use HTTPS to get rid of the mixed content warning. (I did test it, and the image still loads.)
