### PR TITLE
Add support for sending commands to device

### DIFF
--- a/Android/IrssiNotifier/src/fi/iki/murgo/irssinotifier/CommandManager.java
+++ b/Android/IrssiNotifier/src/fi/iki/murgo/irssinotifier/CommandManager.java
@@ -1,0 +1,73 @@
+package fi.iki.murgo.irssinotifier;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.util.Log;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+
+public class CommandManager {
+  private static final String TAG = CommandManager.class.getName();;
+  private static CommandManager instance;
+
+  public static CommandManager getInstance() {
+    if (instance == null) {
+      instance = new CommandManager();
+    }
+    return instance;
+  }
+
+  private CommandManager() {
+  }
+
+  public void handle(Context context, JSONObject payload) {
+    Preferences prefs = new Preferences(context);
+    IrcNotificationManager manager = IrcNotificationManager.getInstance();
+
+    String command;
+
+    try {
+      command = payload.getString("command");
+      command = Crypto.decrypt(prefs.getEncryptionPassword(), command);
+    } catch (CryptoException e) {
+      final int color = prefs.getCustomLightColor();
+
+      NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+      builder.setSmallIcon(R.drawable.notification_icon);
+      builder.setTicker(context.getString(R.string.decryption_error_ticker));
+      builder.setAutoCancel(false);
+      builder.setOngoing(false);
+      builder.setContentText(context.getString(R.string.decryption_error));
+      builder.setContentTitle(context.getString(R.string.decryption_error_title));
+      builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(), 0));
+      builder.setLights(color, 300, 5000);
+
+      final Notification notification = builder.build();
+      final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.notify(666, notification);
+      return;
+    } catch (JSONException e) {
+      // shouldnt happen, JSON payload syntax has already been verified in gcmintentservice
+      return;
+    }
+
+    if (command.equals("clearNotifications")) {
+       Log.d(TAG, "Sending clear unread intent");
+       Intent deleteIntent = new Intent(NotificationClearedReceiver.NOTIFICATION_CLEARED_INTENT);
+       deleteIntent.putExtra("notificationMode", "Single");
+       context.sendBroadcast(deleteIntent);
+       NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+       notificationManager.cancelAll();
+    } else {
+       Log.d(TAG, "Received unknown command '" + command + "'");
+    }
+
+  }
+
+}

--- a/Android/IrssiNotifier/src/fi/iki/murgo/irssinotifier/GCMIntentService.java
+++ b/Android/IrssiNotifier/src/fi/iki/murgo/irssinotifier/GCMIntentService.java
@@ -7,6 +7,9 @@ import android.util.Log;
 import com.google.android.gcm.GCMBaseIntentService;
 import com.google.android.gcm.GCMRegistrar;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class GCMIntentService extends GCMBaseIntentService {
 
     private static final String GCM_DATA_ACTION = "action";
@@ -36,6 +39,18 @@ public class GCMIntentService extends GCMBaseIntentService {
         String action = intent.getStringExtra(GCM_DATA_ACTION);
         String message = intent.getStringExtra(GCM_DATA_MESSAGE);
         Log.d(TAG, "Action: " + action + " Message: " + message);
+
+        // peek into payload to see if it's a message or a command
+        try {
+          JSONObject payload = new JSONObject(message);
+          if (payload.has("command")) {
+            CommandManager manager = CommandManager.getInstance();
+            manager.handle(context, payload);
+            return;
+          }
+        } catch (JSONException e) {
+          // malformed payload, do nothing, ircnotificationmanager will notify user
+        }
 
         IrcNotificationManager manager = IrcNotificationManager.getInstance();
         manager.handle(context, message);

--- a/Server/IrssiNotifierServer/controllers.py
+++ b/Server/IrssiNotifierServer/controllers.py
@@ -239,6 +239,21 @@ class MessageController(BaseController):
         self.response.out.write(response_json)
 
 
+class CommandController(BaseController):
+    def post(self):
+        success = self.initController("CommandController.post()", ["command"])
+        if not success:
+            return self.response
+
+        try:
+            gcmhelper.send_gcm_to_user_deferred(self.irssi_user, json.dumps({"command": self.data['command']}))
+        except:
+            self.response.status = '400 Bad Request'
+            return self.response
+
+        self.response.out.write("")
+
+
 class WipeController(BaseController):
     def post(self):
         success = self.initController("WipeController.post()", [])

--- a/Server/IrssiNotifierServer/main.py
+++ b/Server/IrssiNotifierServer/main.py
@@ -14,6 +14,7 @@ app = webapp2.WSGIApplication(
     [('/', WebController),
      ('/API/Settings', SettingsController),
      ('/API/Message', MessageController),
+     ('/API/Command', CommandController),
      ('/API/Wipe', WipeController),
      ('/API/Nonce', NonceController),
      ('/API/License', LicensingController),


### PR DESCRIPTION
First implemented command is clearNotifications to remotely clear
already read notifications. Like the notifications the command is
also sent encrypted with user password.

For the script this adds a new option called
`irssinotifier_clear_notifications_when_viewed` to clear notifications
on the device when the hilights have been seen in irssi.

The clear notifications command is sent after user changes away
from the last window that had hilights.
