### PR TITLE
Support tmux

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -183,6 +183,9 @@ sub attached {
 }
 
 sub tmux_attached {
+  if (!defined($ENV{'TMUX_PANE'})){
+    return 0;
+  }
   chomp(my $session_attached = `tmux display-message -p -t$ENV{'TMUX_PANE'} '#{session_attached}' 2> /dev/null`);
   chomp(my $window_active    = `tmux display-message -p -t$ENV{'TMUX_PANE'} '#{window_active}' 2> /dev/null`);
   return $session_attached && $window_active;


### PR DESCRIPTION
Support for another terminal multiplexer, tmux, has been added. Further, stderr has been redirected to /dev/null for users who have neither screen or tmux installed.
