### PR TITLE
Improve initial check for notifiability.

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -81,25 +81,19 @@ sub dcc {
 sub print_text {
     my ($dest, $text, $stripped) = @_;
 
-    if (!defined $lastMsg || index($text, $lastMsg) == -1)
-    {
-        # text doesn't contain the message, so printed text is about something else and notification doesn't need to be sent
-        return;
-    }
-
-    if (should_send_notification($dest))
-    {
-        send_notification();
+    # We only need to check that it's a dcc, hilight, or privmsg
+    # before checking whether we need to send.
+    my $opt = MSGLEVEL_HILIGHT | MSGLEVEL_MSGS;
+    if ($lastDcc || (($dest->{level} & $opt) &&
+                     ($dest->{level} & MSGLEVEL_NOHILIGHT) == 0)) {
+        if (should_send_notification($dest)) {
+            send_notification();
+        }
     }
 }
 
 sub should_send_notification {
     my $dest = @_ ? shift : $_;
-
-    my $opt = MSGLEVEL_HILIGHT | MSGLEVEL_MSGS;
-    if (!$lastDcc && (!($dest->{level} & $opt) || ($dest->{level} & MSGLEVEL_NOHILIGHT))) {
-        return 0; # not a hilight and not a dcc message
-    }
 
     if (!are_settings_valid()) {
         return 0; # invalid settings


### PR DESCRIPTION
In print_text, instead of checking that $lastMsg is defined and
that $text is in $lastMsg, check that the event in question is a dcc
msg, hilighted public message, or private message. (This was previously
the first check in should_send_notification.) This will prevent us from
triggering on improper print_text events.

Further:
- Each of these events will have $lastMsg defined.
- By not checking that $text is in $lastMsg, we allow for other scripts
  and irssi internals (such as -word hilights) to modify the line
  between when we record $lastMsg and when $text is passed to print_text
  without preventing irssinotifier from sending a notification.
  (Arguably we should therefore use $text and not $lastMsg, but there's no difference when the only modifications are color codes which are later stripped out anyway)

This resolves #165.