### PR TITLE
Send push notifications with high priority

### DIFF
--- a/Server/IrssiNotifierServer/gcm.py
+++ b/Server/IrssiNotifierServer/gcm.py
@@ -64,7 +64,7 @@ class GCM(object):
         request.add_header('Authorization', 'key=%s' % GCM.authkey)
         request.add_header('Content-Type', 'application/json')
 
-        json_request = {'data': {'message': message}, 'registration_ids': []}
+        json_request = {'data': {'message': message}, 'registration_ids': [], 'priority': 'high'}
         for token in tokens:
             json_request['registration_ids'].append(token.gcm_token)
 


### PR DESCRIPTION
The new Android 6 'doze' power saving mode delays delivery of normal priority push notifications from GCM. A phone that has been sitting on the table without a charger will be in doze mode, and notifiers will be delivered during the next scheduled maintenance round, or the next time the user picks up the device or moves it. Delivering the notifications with high priority will get them delivered immediately even if the device is in doze mode.

https://developers.google.com/cloud-messaging/http-server-ref
https://developer.android.com/training/monitoring-device-state/doze-standby.html