### PR TITLE
Fixed bug where screen socket path wasn't found

### DIFF
--- a/Irssi/irssinotifier.pl
+++ b/Irssi/irssinotifier.pl
@@ -458,7 +458,7 @@ sub event_key_pressed {
 if (defined($ENV{STY})) {
     my $screen_ls = `LC_ALL="C" screen -ls 2> /dev/null`;
     if ($screen_ls !~ /^No Sockets found/s) {
-        $screen_ls =~ /^.+\d+ Sockets? in ([^\n]+)\.\n.+$/s;
+        $screen_ls =~ /^.*\d+ Sockets? in ([^\n]+)\..*$/sm;
         $screen_socket_path = $1;
     } else {
         $screen_ls =~ /^No Sockets found in ([^\n]+)\.\n.+$/s;


### PR DESCRIPTION
It seems as if the script wasn't able to find the `screen` socket path due to the regex being a bit too harsh. I changed the regex a bit - made it multiline and added optional symbols on both sides to make it a bit more robust.

I tested it on my Fedora 23 and it works well.

This bug might have been triggered by a new version of `screen` since I know I fixed something similar in the `screen_away` script earlier.

Hope this is useful!
