### PR TITLE
Set IrcMessage external ID from firebase message ID.

### DIFF
--- a/Android/mobile/src/main/java/fi/iki/murgo/irssinotifier/FancyFcmListenerService.java
+++ b/Android/mobile/src/main/java/fi/iki/murgo/irssinotifier/FancyFcmListenerService.java
@@ -39,6 +39,7 @@ public class FancyFcmListenerService extends FirebaseMessagingService {
             }
 
             msg = new IrcMessage();
+            msg.setExternalId(remoteMessage.getMessageId());
             msg.deserialize(payload);
         } catch (JSONException e) {
             // malformed payload, probably server error or something, who cares


### PR DESCRIPTION
Fixes https://github.com/murgo/IrssiNotifier/issues/201.
See my comment added there with investigation steps.
I'm very much uncertain if this is the correct fix so please review with care.