### PR TITLE
Fix id null check

### DIFF
--- a/Android/mobile/src/main/java/fi/iki/murgo/irssinotifier/IrcMessage.java
+++ b/Android/mobile/src/main/java/fi/iki/murgo/irssinotifier/IrcMessage.java
@@ -27,7 +27,7 @@ public class IrcMessage {
         setChannel(obj.getString("channel"));
         setNick(obj.getString("nick"));
         setServerTimestamp((long) (Double.parseDouble(obj.getString("server_timestamp")) * 1000));
-        if (obj.has("id")) {
+        if (obj.has("id") && !obj.isNull("id")) {
             String externalId = obj.getString("id");
             if (externalId != null && externalId.length() > 0)
                 setExternalId(externalId);


### PR DESCRIPTION
Fixes https://github.com/murgo/IrssiNotifier/issues/201.

The id was resolving as the string "null" here which resulted in all messages being deduped against the id "null".

Verified that this fixes the issue on my device (reliably reproduces without this change, fixed after).