### PR TITLE
Update server to support new firebase

### DIFF
--- a/Server/IrssiNotifierServer/.gcloudignore
+++ b/Server/IrssiNotifierServer/.gcloudignore
@@ -1,0 +1,21 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+.venv/
+
+# Ignored by the build system
+/setup.cfg

--- a/Server/IrssiNotifierServer/.gitignore
+++ b/Server/IrssiNotifierServer/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.venv/
 *.pyc
 secret.txt
 secrets.yaml

--- a/Server/IrssiNotifierServer/app.staging.yaml
+++ b/Server/IrssiNotifierServer/app.staging.yaml
@@ -1,0 +1,38 @@
+#application: irssinotifier
+#version: 2024-rewrite-1-staging
+runtime: python312
+entrypoint: gunicorn -b :$PORT main:app
+
+handlers:
+- url: /favicon.ico
+  static_files: static/favicon.ico
+  upload: static/favicon.ico
+- url: /robots.txt
+  static_files: static/robots.txt
+  upload: static/robots.txt
+- url: /script
+  static_dir: script
+- url: /static
+  static_dir: static
+- url: /cron/clear
+  script: auto
+  login: admin
+- url: /tasks/fcm
+  script: auto
+  login: admin
+- url: /.*
+  script: auto
+  secure: always
+
+builtins:
+- deferred: on
+- appstats: on
+
+env_variables:
+  ENV: 'irssinotifier-stage'
+  PROJECT_NAME: 'irssinotifier-stage'
+  PROJECT_ID: '717656048279'
+  LOCATION: 'us-central1'
+  QUEUE_NAME: 'fcm-queue'
+  BASE_URL: 'https://irssinotifier-stage.appspot.com'
+  LOGIN_REDIRECT_URI: 'https://irssinotifier-stage.appspot.com/oauth2callback'

--- a/Server/IrssiNotifierServer/app.yaml
+++ b/Server/IrssiNotifierServer/app.yaml
@@ -1,8 +1,7 @@
 #application: irssinotifier
-#version: fcm-10
-runtime: python27
-api_version: 1
-threadsafe: true
+#version: 2024-rewrite-1
+runtime: python312
+entrypoint: gunicorn -b :$PORT main:app
 
 handlers:
 - url: /favicon.ico
@@ -16,23 +15,32 @@ handlers:
 - url: /static
   static_dir: static
 - url: /cron/clear
-  script: cron.app
+  script: auto
+  login: admin
+- url: /tasks/fcm
+  script: auto
   login: admin
 - url: /.*
-  script: main.app
+  script: auto
   secure: always
-- url: /tasks/gcm
-  script: gcmqueuehandler.app
-  login: admin
-  
-libraries:
-- name: jinja2
-  version: latest
-- name: pycrypto
-  version: "2.6"
-- name: yaml
-  version: latest
 
 builtins:
 - deferred: on
 - appstats: on
+
+env_variables:
+  PROJECT_NAME: 'IrssiNotifier'
+  PROJECT_ID: '939387723736'
+  LOCATION: 'us-central1'
+  QUEUE_NAME: 'fcm-queue'
+  BASE_URL: 'https://irssinotifier.appspot.com/'
+  LOGIN_REDIRECT_URI: 'https://irssinotifier.appspot.com/oauth2callback'
+
+# Don't forget to create:
+#  - GAE project in https://console.cloud.google.com/appengine/start/reception
+#  - Scheduled task in https://console.cloud.google.com/marketplace/product/google/cloudscheduler.googleapis.com
+#  - Secrets in https://console.cloud.google.com/security/secret-manager
+#  - Tasks queue in 
+#  - Database in
+#  - Logging in
+#  - FCM in https://console.firebase.google.com/

--- a/Server/IrssiNotifierServer/controllers.py
+++ b/Server/IrssiNotifierServer/controllers.py
@@ -1,33 +1,41 @@
-import traceback
-from google.appengine.api import users
-
-import webapp2
+from flask import request, jsonify, render_template, redirect, abort
 import logging
 import licensing
 import login
 import dao
-import gcmhelper
+import fcmhelper
+import json
+import traceback
 import jinja2
 import os
-import json
+
+import secret_manager
 
 jinja_environment = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.dirname(__file__)))
 MinAndroidVersion = 8
 MinScriptVersion = 2
 LatestScriptVersion = 24
 
+LOGIN_REDIRECT_URI = os.getenv('LOGIN_REDIRECT_URI')
+CLIENT_ID = secret_manager.get_secret("oauth2-client-id")
+
+#if not LOGIN_REDIRECT_URI:
+#    LOGIN_REDIRECT_URI = 'http://127.0.0.1:5000/oauth2callback';
+
+login_url = f'https://accounts.google.com/o/oauth2/auth?client_id={CLIENT_ID}&redirect_uri={LOGIN_REDIRECT_URI}&response_type=code&scope=openid%20email'
+logout_url = "/logout"
 
 def getAndroidServerMessage(data):
     if "version" in data:
-        logging.debug("Validating version: " + data["version"])
+        logging.debug("Validating version: " + str(data["version"]))
         try:
             if int(data["version"]) < MinAndroidVersion:
-                logging.warn('Client has too old version')
+                logging.warning('Client has too old version')
                 return (
                     False,
                     "Too old version! Get latest version of IrssiNotifier from https://irssinotifier.appspot.com")
         except ValueError:
-            logging.warn('Client version is not integer')
+            logging.warning('Client version is not integer')
             return (
                 False, "Too old version! Get latest version of IrssiNotifier from https://irssinotifier.appspot.com")
     return True, ""
@@ -40,69 +48,39 @@ def getIrssiServerMessage(data):
                 return (
                     False, "Update your IrssiNotifier script to latest version from https://irssinotifier.appspot.com")
         except ValueError:
-            logging.warn('Irssi script version is not integer')
+            logging.warning('Irssi script version is not integer')
             return False, "Update your IrssiNotifier script to latest version from https://irssinotifier.appspot.com"
     return True, ""
 
 
-class BaseController(webapp2.RequestHandler):
-    data = {}
+class BaseController:
+    def __init__(self):
+        self.data = {}
+        self.irssi_user = None
 
-    def handle_exception(self, exception, debug):
-        # Log the error.
-        logging.exception(exception)
+    def init_controller(self, name, param_requirements, allowApiTokenUse):
+        logging.info(f"Method started: {name}")
 
-        # Set a custom message.
-        self.response.write('An error occurred.')
+        if request.args:
+            self.data = request.args.to_dict()
+        if not self.data and request.get_json(force=True, silent=True):
+            self.data = request.get_json(force=True)
+        if not self.data and request.form:
+            self.data = request.form.to_dict()
+        logging.debug(f"Data {self.data}")
 
-        # If the exception is a HTTPException, use its error code.
-        # Otherwise use a generic 500 error code.
-        if isinstance(exception, webapp2.HTTPException):
-            self.response.set_status(exception.code)
-        else:
-            self.response.set_status(500)
-
-    def initController(self, name, paramRequirements):
-        logging.info("Method started: %s" % name)
-
-        if len(self.request.params) > 0:
-            self.data = self.request.params
-        else:
-            try:
-                self.data = self.decode_params(self.request)
-            except:
-                # because of weird assertion error
-                self.data = {}
-
-        logging.debug("Data {0}".format(self.data))
-
-        self.irssi_user = login.get_irssi_user(self.data)
+        self.irssi_user = login.get_irssi_user(self.data, allowApiTokenUse)
         if not self.irssi_user:
-            self.response.status = "401 Unauthorized"
-            return False
+            abort(401)
 
-        if not self.validate_params(self.data, paramRequirements):
-            self.response.status = "400 Bad Request"
-            return False
+        if not self.validate_params(self.data, param_requirements):
+            abort(400)
         return True
-
-    def decode_params(self, request):
-        d = request.body
-        pairs = d.split('&')
-        data = {}
-        for pair in pairs:
-            if len(pair) < 2:
-                break
-            split = pair.split('=')
-            key = split[0]
-            value = split[1]
-            data[key] = value
-        return data
 
     def validate_params(self, data, params):
         for i in params:
             if i not in data:
-                logging.warn("data error: %s not in %s" % (i, [x for x in data]))
+                logging.warning(f"data error: {i} not in {list(data.keys())}")
                 return False
         return True
 
@@ -110,7 +88,7 @@ class BaseController(webapp2.RequestHandler):
 class WebController(BaseController):
     def get(self):
         logging.debug("WebController.get()")
-        user = login.get_irssi_user(self.request.params)
+        user = login.get_irssi_user(request.args, False)
 
         tokens = []
         irssi_script_version = 0
@@ -122,11 +100,11 @@ class WebController(BaseController):
         license_timestamp = 0
 
         if user is not None:
-            tokens = dao.get_gcm_tokens_for_user(user)
+            tokens = dao.get_fcm_tokens_for_user(user)
 
             for token in tokens:
                 if token.registration_date is not None:
-                    token.registration_date_string = token.registration_date
+                    token.registration_date_string = str(token.registration_date)
                 else:
                     token.registration_date_string = 'Yesterday?'
 
@@ -159,8 +137,8 @@ class WebController(BaseController):
             'tokens': tokens,
             'token_count': len(tokens),
             'logged_in': user is not None,
-            'login_url': users.create_login_url("#profile").replace("&", "&amp;"),
-            'logout_url': users.create_logout_url("").replace("&", "&amp;"),
+            'login_url': login_url,
+            'logout_url': logout_url,
             'irssi_working': irssi_working,
             'irssi_latest': irssi_script_version >= LatestScriptVersion,
             'registration_date': registration_date,
@@ -170,152 +148,144 @@ class WebController(BaseController):
             'license_timestamp': license_timestamp
         }
 
-        template = jinja_environment.get_template('html/index.html')
-        self.response.out.write(template.render(template_values))
+        return render_template('html/index.html', **template_values)
 
 
 class SettingsController(BaseController):
     def post(self):
-        success = self.initController("SettingsController.post()", ["Name", "Enabled", "RegistrationId"])
+        success = self.init_controller("SettingsController.post()", ["Name", "Enabled", "RegistrationId"], True) #todo: should block api token use?
         if not success:
-            return self.response
+            return '', 400
 
-        self.response.headers['Content-Type'] = 'application/json'
-        (cont, serverMessage) = getAndroidServerMessage(self.data)
+        cont, server_message = getAndroidServerMessage(self.data)
         if not cont:
-            self.response.out.write(json.dumps({'servermessage': serverMessage}))
-            return self.response
+            return jsonify({'servermessage': server_message})
 
         dao.save_settings(self.irssi_user, self.data["RegistrationId"], bool(int(self.data["Enabled"])),
                           self.data["Name"])
 
-        responseJson = json.dumps({'response': 'ok'})
-
-        self.response.out.write(responseJson)
+        return jsonify({'response': 'ok'})
 
 
 class MessageController(BaseController):
     def post(self):
-        success = self.initController("MessageController.post()", ["message", "channel", "nick", "version"])
+        success = self.init_controller("MessageController.post()", ["message", "channel", "nick", "version"], True)
         if not success:
-            return self.response
+            return '', 400
 
-        (cont, serverMessage) = getIrssiServerMessage(self.data)
+        if request.args:
+            self.data = request.args.to_dict()
+        if not self.data and request.get_json(force=True, silent=True):
+            self.data = request.get_json(force=True)
+        if not self.data and request.form:
+            self.data = request.form.to_dict()
+        logging.debug(f"MessageController.Post() {self.data}")
+
+        cont, server_message = getIrssiServerMessage(self.data)
         if not cont:
-            self.response.out.write(serverMessage)
-            return self.response
+            return server_message
 
         try:
-            message = dao.add_message(self.irssi_user, self.data["message"], self.data['channel'], self.data['nick'])
+            fcm_message = dao.add_message(self.irssi_user, self.data["message"], self.data['channel'], self.data['nick'])
             dao.update_irssi_user_from_message(self.irssi_user, int(self.data['version']))
-            gcmhelper.send_gcm_to_user_deferred(self.irssi_user, message.to_gcm_json())
-        except:
-            logging.warn("Error while creating new message, exception %s", traceback.format_exc())
-            self.response.status = '400 Bad Request'
-            return self.response
+            self.data['fcm_message'] = fcm_message.to_fcm_json()
+            fcmhelper.send_fcm_to_user_deferred(self.data)
+            dao.update_irssi_user_from_message(self.irssi_user, int(self.data['version']))
+        except Exception:
+            logging.warning(f"Error while creating new message, exception {traceback.format_exc()}")
+            return '', 400
 
-        self.response.out.write(serverMessage)
+        return server_message
 
     def get(self):
-        val = self.initController("MessageController.get()", ["version"])
-        if not val:
-            return self.response
+        success = self.init_controller("MessageController.get()", ["version"], True) # todo allow api key?
+        if not success:
+            return '', 400
 
-        self.response.headers['Content-Type'] = 'application/json'
-        (cont, serverMessage) = getAndroidServerMessage(self.data)
+        cont, server_message = getAndroidServerMessage(self.data)
         if not cont:
-            self.response.out.write(json.dumps({'servermessage': serverMessage, "messages": []}))
-            return self.response
+            return jsonify({'servermessage': server_message, "messages": []})
 
-        if "timestamp" in self.data:
-            timestamp = self.data["timestamp"]
-        else:
-            timestamp = 0
+        timestamp = self.data.get("timestamp", 0)
 
         messages = dao.get_messages(self.irssi_user, timestamp)
         message_jsons = [message.to_json() for message in messages]
-        response_json = json.dumps({"servermessage": serverMessage, "messages": message_jsons})
+        return jsonify({"servermessage": server_message, "messages": message_jsons})
 
-        self.response.out.write(response_json)
+
+class DeferredMessageController(BaseController):
+    def post(self):
+        logging.debug(f'DeferredMessageController.post() {request.data}')
+        fcmhelper._send_fcm_to_user(request);
+        return jsonify({'response': 'ok'})
 
 
 class CommandController(BaseController):
     def post(self):
-        success = self.initController("CommandController.post()", ["command"])
+        success = self.init_controller("CommandController.post()", ["command"], True)
         if not success:
-            return self.response
+            return '', 400
 
         try:
-            gcmhelper.send_gcm_to_user_deferred(self.irssi_user, json.dumps({"command": self.data['command']}))
+            self.data['fcm_message'] = json.dumps({"command": self.data['command']})
+            fcmhelper.send_fcm_to_user_deferred(self.data)
         except:
-            self.response.status = '400 Bad Request'
-            return self.response
+            return '', 400
 
-        self.response.out.write("")
+        return ""
 
 
 class WipeController(BaseController):
     def post(self):
-        success = self.initController("WipeController.post()", [])
+        success = self.init_controller("WipeController.post()", [], False)
         if not success:
-            return self.response
+            return '', 400
 
         if 'RegistrationId' in self.data:
             token_key = self.data['RegistrationId']
-            logging.info('Removing GCM Token: %s' % token_key)
-            token = dao.get_gcm_token_for_id(self.irssi_user, token_key)
+            logging.info('Removing FCM Token: %s' % token_key)
+            token = dao.get_fcm_token_for_id(self.irssi_user, token_key)
             if token is not None:
-                dao.remove_gcm_token(token)
+                dao.remove_fcm_token(token)
             else:
-                logging.warning('GCM Token to be removed not found!')
+                logging.warning('FCM Token to be removed not found!')
         else:
             dao.wipe_user(self.irssi_user)
 
-        responseJson = json.dumps({'response': 'ok'})
-        self.response.headers['Content-Type'] = 'application/json'
-        self.response.out.write(responseJson)
+        return login.logout()
 
 
-class AdminController(BaseController):
-    def get(self):
-        from gcm import GCM
-        GCM.authkey = None
-        self.redirect('https://appengine.google.com/dashboard?&app_id=s~irssinotifier')
-
-
-class AnalyticsController(BaseController):
-    def get(self):
-        self.redirect(
-            'https://www.google.com/analytics/web/?pli=1#report/visitors-overview/a29331277w55418008p56422952/')
-
-
-class CronController(webapp2.RequestHandler):
+#untested with new version
+class CronController:
     def get(self):
         logging.info("Clearing data")
         dao.clear_old_messages()
+        return '', 200
 
 
+#untested with new version
 class NonceController(BaseController):
     def get(self):
-        val = self.initController("NonceController.get()", [])
-        if not val:
-            return self.response
+        success = self.init_controller("NonceController.get()", [], True) # todo allow api key?
+        if not success:
+            return '', 400
 
         nonce = dao.get_new_nonce(self.irssi_user)
-        self.response.out.write(nonce.nonce)
+        return str(nonce.nonce)
 
 
+#untested with new version
 class LicensingController(BaseController):
     def post(self):
-        val = self.initController("LicensingController.post()", ['SignedData', 'Signature'])
-        if not val:
-            return self.response
+        success = self.init_controller("LicensingController.post()", ['SignedData', 'Signature'], True) # todo allow api key?
+        if not success:
+            return '', 400
 
         logging.info('Verifying license for user %s' % self.irssi_user.email)
 
         ok = licensing.Licensing().check_license(self.irssi_user, self.data['SignedData'], self.data['Signature'])
 
         if ok:
-            self.response.out.write('OK')
+            return 'OK'
         else:
-            self.response.status = '403 Forbidden'
+            return '', 403

--- a/Server/IrssiNotifierServer/dao.py
+++ b/Server/IrssiNotifierServer/dao.py
@@ -1,85 +1,92 @@
 import time
-import traceback
 import uuid
-from Crypto.Random import random
-from google.appengine.api import memcache
-
+from google.cloud import ndb
+import logging
 from datamodels import *
-from google.appengine.ext import ndb
-import yaml
+import random
 
 OldMessageRemovalThreshold = 7 * 24 * 60 * 60
 
+# Initialize NDB client
+client = ndb.Client()
 
-# gcm token stuff
+# fcm token stuff
 
-def get_gcm_token_for_key(token_key):
-    return token_key.get()
+def get_fcm_token_for_key(token_key):
+    with client.context():
+        return token_key.get()
 
+def get_fcm_token_for_id(irssi_user, token_key):
+    with client.context():
+        query = GcmToken.query(GcmToken.gcm_token == token_key, ancestor=irssi_user.key)
+        return query.get()
 
-def get_gcm_token_for_id(irssi_user, token_key):
-    query = GcmToken.query(GcmToken.gcm_token == token_key, ancestor=irssi_user.key)
-    return query.get()
+def get_fcm_tokens_for_user(user):
+    return get_fcm_tokens_for_user_key(user.key, True)
 
+def get_fcm_tokens_for_user_key(irssi_user_key, include_disabled=False):
+    with client.context():
+        query = GcmToken.query(ancestor=irssi_user_key)
+        if not include_disabled:
+            query = query.filter(GcmToken.enabled == True)  # must be ==
+        tokensList = ndb.get_multi(query.fetch(keys_only=True))
+        return tokensList
 
-def get_gcm_tokens_for_user(user):
-    return get_gcm_tokens_for_user_key(user.key, True)
+def remove_fcm_token(token):
+    with client.context():
+        token.key.delete()
 
-
-def get_gcm_tokens_for_user_key(irssi_user_key, include_disabled=False):
-    query = GcmToken.query(ancestor=irssi_user_key)
-    if not include_disabled:
-        query = query.filter(GcmToken.enabled == True)  # must be ==
-    tokensList = ndb.get_multi(query.fetch(keys_only=True))
-    return tokensList
-
-
-def remove_gcm_token(token):
-    token.key.delete()
-
-
-def update_gcm_token(token, new_token_id):
-    token.gcm_token = new_token_id
-    token.put()
-
+def update_fcm_token(token, new_token_id):
+    with client.context():
+        token.gcm_token = new_token_id
+        token.put()
 
 # irssi user stuff
 
 def get_irssi_user_for_api_token(token):
-    api_token_key = "api-token" + str(token)
-    user = memcache.get(api_token_key)
-    if user is not None:
-        return user
+    #api_token_key = "api-token" + str(token)
+    #user = get_memcache_value(api_token_key)
+    #if user is not None:
+    #    return user
 
-    query = IrssiUser.query(IrssiUser.api_token == token)
-    user = query.get()
+    with client.context():
+        query = IrssiUser.query(IrssiUser.api_token == token)
+        user = query.get()
 
-    memcache.set(api_token_key, user)
+    #set_memcache_value(api_token_key, user)
     return user
 
-
-def get_irssi_user_for_key_name(key_name):
-    return IrssiUser.get_by_id(key_name)
-
+# email parameter is a fallback since the user ids (PKs) changed when migrating from Users to OAuth2
+def get_irssi_user_for_key_name(key_name, email):
+    with client.context():
+        #user = IrssiUser.get_by_id(key_name)
+        user = IrssiUser.query(IrssiUser.user_id_oauth2 == key_name).get()
+        if user is None:
+            user = IrssiUser.query(IrssiUser.email == email).get()
+            if user is not None:
+                # update new id into user row
+                user.user_id_oauth2 = key_name
+                logging.info(f'Migrating {user.email} to have key {user.user_id_oauth2}')
+                user.put()
+        return user
 
 def generate_api_token():
     return str(uuid.uuid4())
 
+def add_irssi_user(email, user_id=None):
+    with client.context():
+        irssi_user = IrssiUser(id=user_id)
+        irssi_user.user_id_oauth2 = user_id
+        irssi_user.user_name = "Anonymous"
+        irssi_user.email = email
+        irssi_user.api_token = generate_api_token()
+        irssi_user.registration_date = int(time.time())
+        irssi_user.put()
 
-def add_irssi_user(user, user_id=None):
-    irssi_user = IrssiUser(id=user_id)
-    irssi_user.user_id = user_id
-    irssi_user.user_name = user.nickname()
-    irssi_user.email = user.email()
-    irssi_user.api_token = generate_api_token()
-    irssi_user.registration_date = int(time.time())
-    irssi_user.put()
-
-    api_token_key = "api-token" + str(irssi_user.api_token)
-    memcache.set(api_token_key, irssi_user)
-
+    #api_token_key = "api-token" + str(irssi_user.api_token)
+    #set_memcache_value(api_token_key, irssi_user)
+    
     return irssi_user
-
 
 def update_irssi_user_from_message(irssi_user, version):
     logging.debug("updating irssi user")
@@ -101,130 +108,110 @@ def update_irssi_user_from_message(irssi_user, version):
         irssi_user.irssi_script_version = version
 
     if modified:
-        irssi_user.put()
-        api_token_key = "api-token" + str(irssi_user.api_token)
-        memcache.set(api_token_key, irssi_user)
+        with client.context():
+            irssi_user.put()
+        #api_token_key = "api-token" + str(irssi_user.api_token)
+        #set_memcache_value(api_token_key, irssi_user)
 
     return irssi_user
-
-
-# gcm auth key stuff
-
-def load_gcm_auth_key():
-    # for some reason old secret is gotten from DB forever, temp hax to read it straight from file
-    #key = Secret.get_by_id("GCM_AUTHKEY")
-    #if key is None:
-    #    key = add_gcm_auth_key()
-    #    if key is None:
-    #        return None
-    #return key.secret
-    return get_secret('google_api_key')
-
-
-def add_gcm_auth_key():
-    authkey = get_secret('google_api_key')
-    logging.info("GCM Auth Key: %s" % authkey)
-
-    key = Secret(id="GCM_AUTHKEY")
-    key.secret = authkey
-    key.put()
-    return key
-
 
 # message stuff
 
 def get_messages(user, timestamp):
     logging.debug("Getting messages after: %s" % timestamp)
-    query = Message.query(Message.server_timestamp > int(timestamp), ancestor=user.key).order(Message.server_timestamp)
-
-    m = query.fetch(50)
+    with client.context():
+        query = Message.query(Message.server_timestamp > int(timestamp), ancestor=user.key).order(Message.server_timestamp)
+        m = query.fetch(50)
     logging.debug("Found %s messages" % len(m))
     return m
 
-
 def add_message(irssi_user, message=None, channel=None, nick=None):
-    msg = Message(parent=irssi_user.key)
-    msg.message = message
-    msg.channel = channel
-    msg.nick = nick
-    msg.server_timestamp = int(time.time())
-    if irssi_user.license_timestamp is not None:
-        logging.debug("Licensed user, saving message")
-        msg.put()
-    else:
-        logging.debug("Free user, not saving message")
+    with client.context():
+        msg = Message(parent=irssi_user.key)
+        msg.message = message
+        msg.channel = channel
+        msg.nick = nick
+        msg.server_timestamp = int(time.time())
+        if irssi_user.license_timestamp is not None:
+            logging.debug("Licensed user, saving message")
+            msg.put()
+        else:
+            logging.debug("Free user, not saving message")
     return msg
-
 
 def clear_old_messages():
     MaxAmount = 500
     amount = MaxAmount
 
     logging.info("Clearing old messages")
-    while amount == MaxAmount:
-        query = Message.query(Message.server_timestamp < (int(time.time()) - OldMessageRemovalThreshold))
-        keys = query.fetch(MaxAmount, keys_only=True)
-        ndb.delete_multi(keys)
-        amount = len(keys)
-        logging.info("Deleted %s messages" % amount)
-
+    with client.context():
+        while amount == MaxAmount:
+            query = Message.query(Message.server_timestamp < (int(time.time()) - OldMessageRemovalThreshold))
+            keys = query.fetch(MaxAmount, keys_only=True)
+            ndb.delete_multi(keys)
+            amount = len(keys)
+            logging.info("Deleted %s messages" % amount)
 
 # settings stuff
 
 def save_settings(user, token_id, enabled, name):
-    token = get_gcm_token_for_id(user, token_id)
+    token = get_fcm_token_for_id(user, token_id)
 
     if token is not None:
         logging.debug("Updating token: " + token_id)
         token.enabled = enabled
         token.name = name
-        token.put()
+        with client.context():
+            token.put()
         return token
 
     logging.debug("Adding new token: " + token_id)
-    tokenToAdd = GcmToken(parent=user.key)
-    tokenToAdd.gcm_token = token_id
-    tokenToAdd.enabled = enabled
-    tokenToAdd.name = name
-    tokenToAdd.registration_date = int(time.time())
-    tokenToAdd.put()
+    with client.context():
+        tokenToAdd = GcmToken(parent=user.key)
+        tokenToAdd.gcm_token = token_id
+        tokenToAdd.enabled = enabled
+        tokenToAdd.name = name
+        tokenToAdd.registration_date = int(time.time())
+        tokenToAdd.put()
     return tokenToAdd
 
-
 def wipe_user(user):
-    logging.info("Wiping everything for user %s" % user.user_id)
+    logging.info("Wiping everything for user %s" % user.email)
 
     key = user.key
     MaxAmount = 500
 
-    api_token_key = "api-token" + str(user.api_token)
-    memcache.delete(api_token_key)
+    #api_token_key = "api-token" + str(user.api_token)
+    #set_memcache_value(api_token_key, None)
 
     amount = MaxAmount
     logging.info("Wiping messages")
-    while amount == MaxAmount:
-        query = Message.query(ancestor=key)
-        keys = query.fetch(MaxAmount, keys_only=True)
-        ndb.delete_multi(keys)
-        amount = len(keys)
-        logging.info("Deleted %s messages" % amount)
+    with client.context():
+        while amount == MaxAmount:
+            query = Message.query(ancestor=key)
+            keys = query.fetch(MaxAmount, keys_only=True)
+            ndb.delete_multi(keys)
+            amount = len(keys)
+            logging.info("Deleted %s messages" % amount)
 
     amount = MaxAmount
-    logging.info("Wiping GCM tokens")
-    while amount == MaxAmount:
-        query = GcmToken.query(ancestor=key)
-        keys = query.fetch(MaxAmount, keys_only=True)
-        ndb.delete_multi(keys)
-        amount = len(keys)
-        logging.info("Deleted %s tokens" % amount)
+    logging.info("Wiping FCM tokens")
+    with client.context():
+        while amount == MaxAmount:
+            query = GcmToken.query(ancestor=key)
+            keys = query.fetch(MaxAmount, keys_only=True)
+            ndb.delete_multi(keys)
+            amount = len(keys)
+            logging.info("Deleted %s tokens" % amount)
 
     logging.info("Wiping user")
-    user.key.delete()
-
+    with client.context():
+        user.key.delete()
 
 def get_new_nonce(user):
-    query = Nonce.query(ancestor=user.key).order(-Nonce.issue_timestamp)
-    nonce = query.get()
+    with client.context():
+        query = Nonce.query(ancestor=user.key).order(-Nonce.issue_timestamp)
+        nonce = query.get()
 
     nonce_expiration_time = 20 * 60
 
@@ -238,47 +225,18 @@ def get_new_nonce(user):
     else:
         logging.debug("Old nonce is too old, generating new one: %s. Old: %s, now: %s" % (rand, nonce, int(time.time())))
 
-    nonce = Nonce(parent=user.key)
-    nonce.issue_timestamp = int(time.time())
-    nonce.nonce = rand
-    nonce.put()
+    with client.context():
+        nonce = Nonce(parent=user.key)
+        nonce.issue_timestamp = int(time.time())
+        nonce.nonce = rand
+        nonce.put()
 
     return nonce
 
-
 def get_nonce(user, nonce):
-    query = Nonce.query(Nonce.nonce == nonce, ancestor=user.key)
-    return query.get()
-
-
-def load_licensing_public_key():
-    key = Secret.get_by_id("LICENSING_PUBLIC_KEY")
-    if key is None:
-        key = add_licensing_public_key()
-        if key is None:
-            return None
-    return key.secret
-
-
-def add_licensing_public_key():
-    authkey = get_secret('licensing_public_key')
-    logging.info("Licensing public key: %s" % authkey)
-
-    key = Secret(id="LICENSING_PUBLIC_KEY")
-    key.secret = authkey
-    key.put()
-    return key
-
-
-def get_secret(secret_name):
-    try:
-        with open("secrets.yaml") as f:
-            secrets = yaml.load(f)
-            return secrets[secret_name]
-    except:
-        logging.error("Unable to read secrets.yaml %s" % traceback.format_exc())
-        return None
-
+    with client.context():
+        query = Nonce.query(Nonce.nonce == nonce, ancestor=user.key)
+        return query.get()
 
 def save_license(irssi_user, response_code, nonce, package_name, version_code, user_id, timestamp, extra_data):
     logging.info("User %s licensed!" % irssi_user.email)
@@ -288,18 +246,20 @@ def save_license(irssi_user, response_code, nonce, package_name, version_code, u
     if irssi_user.license_timestamp is None:
         logging.info("User %s first time licensing, cool. Current time: %s" % (irssi_user.email, current_time))
         irssi_user.license_timestamp = current_time
-        irssi_user.put()
+        with client.context():
+            irssi_user.put()
 
-    api_token_key = "api-token" + str(irssi_user.api_token)
-    memcache.set(api_token_key, irssi_user)
+    #api_token_key = "api-token" + str(irssi_user.api_token)
+    #set_memcache_value(api_token_key, irssi_user)
 
-    l = License(parent=irssi_user.key)
-    l.response_code = response_code
-    l.nonce = nonce
-    l.package_name = package_name
-    l.version_code = version_code
-    l.user_id = user_id
-    l.timestamp = timestamp
-    l.extra_data = extra_data
-    l.receive_timestamp = current_time
-    l.put()
+    with client.context():
+        l = License(parent=irssi_user.key)
+        l.response_code = response_code
+        l.nonce = nonce
+        l.package_name = package_name
+        l.version_code = version_code
+        l.user_id = user_id
+        l.timestamp = timestamp
+        l.extra_data = extra_data
+        l.receive_timestamp = current_time
+        l.put()

--- a/Server/IrssiNotifierServer/datamodels.py
+++ b/Server/IrssiNotifierServer/datamodels.py
@@ -1,16 +1,13 @@
 import json
 import logging
-from google.appengine.ext import ndb
-
-
-class Secret(ndb.Model):
-    secret = ndb.StringProperty()
+from google.cloud import ndb
 
 
 class IrssiUser(ndb.Model):
-    user_name = ndb.StringProperty(indexed=False)
+    user_name = ndb.StringProperty(indexed=True)
     email = ndb.StringProperty(indexed=True)
     user_id = ndb.StringProperty(indexed=True)
+    user_id_oauth2 = ndb.StringProperty(indexed=True)
     api_token = ndb.StringProperty(indexed=True)
     registration_date = ndb.IntegerProperty(indexed=False)
     notification_count_since_licensed = ndb.IntegerProperty(indexed=False)
@@ -19,10 +16,11 @@ class IrssiUser(ndb.Model):
     license_timestamp = ndb.IntegerProperty(indexed=False)
 
 
+# use GcmToken and gcm_token to comply with old database (instead of "Fcm")
 class GcmToken(ndb.Model):
     gcm_token = ndb.StringProperty(indexed=True)
     enabled = ndb.BooleanProperty(indexed=True)
-    name = ndb.StringProperty(indexed=False)
+    name = ndb.StringProperty(indexed=True)
     registration_date = ndb.IntegerProperty(indexed=False)
 
 
@@ -43,7 +41,7 @@ class Message(ndb.Model):
              'nick': self.nick,
              'id': self.key.integer_id()})
 
-    def to_gcm_json(self):
+    def to_fcm_json(self):
         values = {'server_timestamp': '%f' % self.server_timestamp,
                   'message': self.message,
                   'channel': self.channel,

--- a/Server/IrssiNotifierServer/deploy.bat
+++ b/Server/IrssiNotifierServer/deploy.bat
@@ -1,1 +1,7 @@
-gcloud app deploy -v fcm-10
+REM ---- To install dependencies
+REM pip install -r requirements.txt
+
+REM ---- To run locally
+REM python main.py
+
+gcloud app deploy -v fcm-deprecated-1

--- a/Server/IrssiNotifierServer/fcm.py
+++ b/Server/IrssiNotifierServer/fcm.py
@@ -1,0 +1,135 @@
+import json
+import socket
+import traceback
+import requests
+import logging
+import os
+
+import dao
+import firebase_login
+
+PROJECT_ID = os.getenv('PROJECT_ID')
+#PROJECT_ID = "irssinotifier-staging"
+FcmUrl = f'https://fcm.googleapis.com/v1/projects/{PROJECT_ID}/messages:send'
+
+
+def is_set(key, arr):
+    return key in arr and arr[key] is not None and arr[key] != ""
+
+class FCM(object):
+    authkey = None
+
+    def __init__(self):
+        self.tokens = []
+        if FCM.authkey is None:
+            # use firebase credentials to refresh access token
+            FCM.authkey = firebase_login.getBearerToken()
+            if FCM.authkey is None:
+                raise Exception("No auth key for FCM!")
+
+    def send_fcm_to_user(self, irssiuser_key, message):
+        #logging.debug("Sending fcm message to user %s", irssiuser_key)
+        if FCM.authkey is None:
+            logging.error("No auth key for FCM!")
+            return
+
+        tokens = dao.get_fcm_tokens_for_user_key(irssiuser_key)
+        self.send_fcm(tokens, message)
+
+    def send_fcm(self, tokens, message):
+        self.tokens = tokens
+        logging.info("Sending FCM message to %s tokens", len(self.tokens))
+        if FCM.authkey is None:
+            logging.error("No auth key for FCM!")
+            return
+
+        if len(self.tokens) == 0:
+            logging.info("No tokens, stop sending")
+            return
+
+        response_json = self.send_request(message, self.tokens)
+        if response_json is None:
+            return  # instant failure
+
+        if response_json['failure'] == '0' and response_json['canonical_ids'] == '0':
+            return  # success
+
+        results = response_json["results"]
+        index = -1
+        for result in results:
+            index += 1
+            token = self.tokens[index]
+            self.handle_fcm_result(result, token, message)
+
+    def send_request(self, message, tokens):
+        headers = {
+            'Authorization': 'Bearer %s' % FCM.authkey,
+            'Content-Type': 'application/json; UTF-8',
+        }
+
+        json_request = {
+            'message': {
+                'token': '',
+                'data': {'message': message},
+                'android': {'priority': 'high'},
+            }
+        }
+
+        response_body = ''
+
+        try:
+            for token in tokens:
+                json_request['message']['token'] = token.gcm_token
+                logging.debug(f"Posting FCM send request to {FcmUrl} , request: {json.dumps(json_request)}")
+                response = requests.post(FcmUrl, headers=headers, json=json_request)
+                response_body = response.text
+                logging.debug("FCM Message sent, response: %s" % response_body)
+                if response.status_code == 200:
+                    return response.json()
+                else:
+                    logging.error(
+                        "Unable to send FCM message! Response code: %s, response body: %s " % (response.status_code, response_body))
+                    return None  # do not retry
+        except requests.exceptions.RequestException as e:
+            logging.warning("RequestException: Unable to send FCM message! %s" % traceback.format_exc())
+            raise Exception("NOMAIL %s " % e)  # retry
+        except socket.error as e:
+            logging.warning("socket.error: Unable to send FCM message! %s" % traceback.format_exc())
+            raise Exception("NOMAIL %s " % e)  # retry
+        except:
+            logging.error("Unable to send FCM message! %s" % traceback.format_exc())
+            return None
+
+    def handle_fcm_result(self, result, token, message):
+        if is_set("message_id", result):
+            if is_set("registration_id", result):
+                new_token = result["registration_id"]
+                self.replace_fcm_token_with_canonical(token, new_token)
+        else:
+            if is_set("error", result):
+                error = result["error"]
+                logging.warning("Error sending FCM message with authkey %s: %s" % (FCM.authkey, error))
+                if error == "Unavailable":
+                    logging.warning("Token unavailable, retrying")
+                    #fcmhelper.send_fcm_to_token_deferred(token, message)
+                elif error == "NotRegistered":
+                    logging.warning("Token not registered, deleting token")
+                    dao.remove_fcm_token(token)
+                elif error == "InvalidRegistration":
+                    logging.error("Invalid registration, deleting token")
+                    dao.remove_fcm_token(token)
+                else:
+                    if error == "InternalServerError":
+                        logging.warning("InternalServerError in FCM: " + error)
+                    else:
+                        logging.error("Unrecoverable error in FCM: " + error)
+
+    def replace_fcm_token_with_canonical(self, token, new_token_id):
+        already_exists = new_token_id in [t.gcm_token for t in self.tokens]
+
+        if already_exists:
+            logging.info("Canonical token already exists, removing old one: %s" % (new_token_id))
+            dao.remove_fcm_token(token)
+        else:
+            logging.info("Updating token with canonical token: %s -> %s" % (token.gcm_token, new_token_id))
+            dao.update_fcm_token(token, new_token_id)

--- a/Server/IrssiNotifierServer/fcm_test.py
+++ b/Server/IrssiNotifierServer/fcm_test.py
@@ -1,0 +1,77 @@
+import logging
+from datamodels import GcmToken
+from fcm import FCM
+import json
+import unittest
+
+
+class MockDao():
+    def __init__(self):
+        self.removed_tokens = []
+        self.updated_tokens = []
+
+    def load_fcm_auth_key(self):
+        return '123'
+
+    def remove_fcm_token(self, token):
+        self.removed_tokens.append(token)
+
+    def update_fcm_token(self, token, new_token_id):
+        self.updated_tokens.append((token, new_token_id))
+
+
+class MockFcmHelper():
+    def __init__(self):
+        self.sent_tokens = []
+
+    def send_fcm_to_token_deferred(self, token, message):
+        self.sent_tokens.append((token, message))
+
+
+class TestFcm(unittest.TestCase):
+
+    def test_canonical_ids(self):
+        logging.root.setLevel(logging.DEBUG)
+
+        mock_dao = MockDao()
+        mock_helper = MockFcmHelper()
+        fcm = FCM(mock_dao, mock_helper)
+        fcm.tokens = [GcmToken(fcm_token='0'), GcmToken(fcm_token='1'), GcmToken(fcm_token='2'),
+                      GcmToken(fcm_token='3'), GcmToken(fcm_token='4'), GcmToken(fcm_token='5'),
+                      GcmToken(fcm_token='6'), GcmToken(fcm_token='7')]
+
+        message = 'testing testing 1 2 3'
+
+        response = {'multicast_id': 666, 'success': 4, 'canonical_ids': 2,
+                    'results': [
+                        {'error': 'something else'},
+                        {'message_id': '11'},  # success
+                        {'message_id': '22', 'registration_id': '3'},  # message with already existing canonical id
+                        {'message_id': '33'},  # canonical id for previous
+                        {'message_id': '44', 'registration_id': '123'},  # totally new canonical id
+                        {'error': 'NotRegistered'},  # not registered
+                        {'error': 'Unavailable'},
+                        {'error': 'something else'}
+                    ]}
+
+        js = json.dumps(response)
+
+        response_json = json.loads(js)
+        results = response_json["results"]
+        index = -1
+        for result in results:
+            index += 1
+            token = fcm.tokens[index]
+            fcm.handle_fcm_result(result, token, message)
+
+        self.assertEqual(2, len(mock_dao.removed_tokens))
+        self.assertEqual('2', mock_dao.removed_tokens[0].gcm_token)
+        self.assertEqual('5', mock_dao.removed_tokens[1].gcm_token)
+
+        self.assertEqual(1, len(mock_dao.updated_tokens))
+        self.assertEqual('4', mock_dao.updated_tokens[0][0].gcm_token)
+        self.assertEqual('123', mock_dao.updated_tokens[0][1])
+
+        self.assertEqual(1, len(mock_helper.sent_tokens))
+        self.assertEqual('6', mock_helper.sent_tokens[0][0].gcm_token)
+        self.assertEqual(message, mock_helper.sent_tokens[0][1])

--- a/Server/IrssiNotifierServer/fcmhelper.py
+++ b/Server/IrssiNotifierServer/fcmhelper.py
@@ -1,0 +1,92 @@
+import traceback
+import logging
+import json
+import os
+from google.cloud import tasks_v2
+import base64
+
+from fcm import FCM
+import login
+
+# Read environment variables
+PROJECT_NAME = os.getenv('PROJECT_NAME').lower()
+LOCATION = os.getenv('LOCATION')
+QUEUE_NAME = os.getenv('QUEUE_NAME')
+BASE_URL = os.getenv('BASE_URL')
+
+# Construct the URL dynamically
+SERVICE = os.getenv('GAE_SERVICE', 'default')
+VERSION = os.getenv('GAE_VERSION', 'v1')
+INSTANCE = os.getenv('GAE_INSTANCE', 'instance')
+
+def create_task(payload):
+    client = tasks_v2.CloudTasksClient()
+
+    # Convert the payload to JSON and then to base64
+    payload = json.dumps(payload)
+    converted_payload = base64.b64encode(payload.encode()).decode()
+
+    # Construct the request body.
+    task = tasks_v2.Task(
+        http_request=tasks_v2.HttpRequest(
+            http_method=tasks_v2.HttpMethod.POST,
+            url=f'{BASE_URL}/API/DeferredMessage',
+            headers={"Content-type": "application/json"},
+            body=converted_payload,
+        ),
+    )
+
+    # THIS TASK IS CREATED AS THE DEFAULT COMPUTE SERVICE ACCOUNT, NOT THE USUAL ACCOUNT?
+
+    # Use the client to build and send the task.
+    logging.info(f'Creating deferred message task, queue path: {client.queue_path(PROJECT_NAME, LOCATION, QUEUE_NAME)}...')
+    #logging.info(f'creating task {task}')
+    return client.create_task(
+        tasks_v2.CreateTaskRequest(
+            parent=client.queue_path(PROJECT_NAME, LOCATION, QUEUE_NAME),
+            task=task,
+        )
+    )
+
+def send_fcm_to_user_deferred(data):
+    logging.info("Queuing deferred task for sending message to user")
+    try:
+        create_task(data)
+    except Exception as e:
+        logging.warn("Error creating task: %s" % traceback.format_exc())
+
+def _send_fcm_to_user(request):
+    #logging.debug(f'request: {request}')
+    logging.debug(f'data: {request.data}')
+    #payload = json.loads(base64.b64decode(request.data).decode())
+    payload = json.loads(request.data)
+    irssi_user = login.get_irssi_user(payload, True)
+    fcm_message = payload['fcm_message']
+    logging.info("Executing deferred task: _send_fcm_to_user, %s, %s" % (irssi_user.email, fcm_message))
+    fcm = FCM()
+    fcm.send_fcm_to_user(irssi_user.key, fcm_message)
+
+'''
+def send_fcm_to_token_deferred(token, message):
+    logging.info("Queuing deferred task for sending message to token %s" % token.gcm_token)
+    key = token.key
+    try:
+        payload = {
+            'function': '_send_fcm_to_token',
+            'key': key,
+            'message': message
+        }
+        create_task(payload)
+    except Exception as e:
+        logging.warn("Error creating task: %s" % traceback.format_exc())
+
+def _send_fcm_to_token(request):
+    payload = json.loads(base64.b64decode(request.data).decode())
+    token_key = payload['key']
+    message = payload['message']
+    logging.info("Executing deferred task: _send_fcm_to_token, %s, %s" % (token_key, message))
+    token = dao.get_fcm_token_for_key(token_key)
+
+    fcm = FCM(dao, sys.modules[__name__])
+    fcm.send_fcm([token], message)
+'''

--- a/Server/IrssiNotifierServer/firebase_login.py
+++ b/Server/IrssiNotifierServer/firebase_login.py
@@ -1,0 +1,23 @@
+import json
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+import secret_manager
+
+def getBearerToken():
+    # Scopes required for FCM
+    SCOPES = ['https://www.googleapis.com/auth/firebase.messaging']
+
+    service_account_info = json.loads(secret_manager.get_secret("firebase-messaging-service-account-info"))
+
+    # Load the service account credentials
+    credentials = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=SCOPES)
+
+    # Refresh the token (if necessary)
+    credentials.refresh(Request())
+
+    # Get the OAuth 2.0 token
+    token = credentials.token
+    print("OAuth 2.0 Bearer Token:", token)
+    return token

--- a/Server/IrssiNotifierServer/licensing.py
+++ b/Server/IrssiNotifierServer/licensing.py
@@ -1,10 +1,12 @@
 import base64
 import logging
-from Crypto.Hash import SHA
+from Crypto.Hash import SHA1  # Updated to SHA1 for compatibility
 from Crypto.PublicKey import RSA
-from Crypto.Signature import PKCS1_v1_5
+from Crypto.Signature import pkcs1_15  # Updated to pkcs1_15 for compatibility
 import dao
+import secret_manager
 
+#untested
 
 class Licensing(object):
     public_key = None
@@ -12,12 +14,12 @@ class Licensing(object):
 
     def __init__(self):
         if Licensing.public_key_base64 is None:
-            Licensing.public_key_base64 = dao.load_licensing_public_key()
+            Licensing.public_key_base64 = secret_manager.get_secret("licensing_public_key")
             if Licensing.public_key_base64 is None:
                 raise Exception("No key for licensing!")
 
             # Key from Google Play is a X.509 subjectPublicKeyInfo DER SEQUENCE.
-            Licensing.public_key = RSA.importKey(base64.standard_b64decode(Licensing.public_key_base64))
+            Licensing.public_key = RSA.import_key(base64.standard_b64decode(Licensing.public_key_base64))
 
     def check_license(self, irssi_user, signed_data, signature):
         signed_data = signed_data.replace('%3D', '=').replace('%26', '&').replace('%2F', '/').replace('%2B', '+')
@@ -37,7 +39,7 @@ class Licensing(object):
             version_code = fields[3]
             user_id = fields[4]
             timestamp = int(fields[5])
-        except:
+        except Exception as e:
             logging.error("Malformed data in licensing: %s" % signed_data)
             return False
 
@@ -50,13 +52,17 @@ class Licensing(object):
             logging.error("Nonces do not match! given: %s" % nonce)
             return False
 
-        h = SHA.new()
-        h.update(signed_data)
+        h = SHA1.new()
+        h.update(signed_data.encode('utf-8'))  # Ensure data is encoded to bytes
         # Scheme is RSASSA-PKCS1-v1_5.
-        verifier = PKCS1_v1_5.new(Licensing.public_key)
+        verifier = pkcs1_15.new(Licensing.public_key)
         # The signature is base64 encoded.
         signature = base64.standard_b64decode(signature)
-        verified = verifier.verify(h, signature)
+        try:
+            verifier.verify(h, signature)
+            verified = True
+        except (ValueError, TypeError):
+            verified = False
 
         logging.info("Verified: %s " % verified)
 

--- a/Server/IrssiNotifierServer/login.py
+++ b/Server/IrssiNotifierServer/login.py
@@ -1,13 +1,61 @@
-from google.appengine.api import users
 import logging
+import os
 import dao
+from flask import request, session, redirect
+from google.oauth2 import id_token
+from google.auth.transport import requests as authrequests
+import requests
+
+import secret_manager
 
 
-def get_irssi_user(params):
+def oauth2callback():
+    code = request.args.get('code')
+    if not code:
+        return 'Authorization failed.'
+
+    LOGIN_REDIRECT_URI = os.getenv('LOGIN_REDIRECT_URI')
+    CLIENT_ID = secret_manager.get_secret("oauth2-client-id")
+
+    try:
+        # Exchange the authorization code for an access token
+        token_response = requests.post(
+            'https://oauth2.googleapis.com/token',
+            data={
+                'code': code,
+                'client_id': CLIENT_ID,
+                'client_secret': secret_manager.get_secret('oauth2-client-secret'),
+                'redirect_uri': LOGIN_REDIRECT_URI,
+                'grant_type': 'authorization_code'
+            }
+        )
+
+        token_data = token_response.json()
+        logging.debug(token_data)
+
+        # Check if the access token is present
+        if 'id_token' in token_data:
+            session['id_token'] = token_data['id_token']
+            return redirect("/#profile");
+        else:
+            return f"Authorization failed. Error: {token_data.get('error_description', 'Unknown error')}"
+    except Exception as e:
+        logging.error(f"Error during token exchange: {str(e)}")
+        return f"Authorization failed. Error: {str(e)}"
+
+def logout():
+    session.clear()
+    return redirect("/");
+
+def get_irssi_user(params, allowApiTokenUse):
     logging.info("Login.getIrssiUser()")
-    user = users.get_current_user()
-    if not user:
-        logging.debug("No Google user found, using API token")
+
+    if 'id_token' not in session:
+        if not allowApiTokenUse:
+            logging.debug("No OAuth Login and not allowing to use API token, failing")
+            return None
+
+        logging.debug("No OAuth Login, using API token")
         if 'apiToken' not in params:
             logging.debug("No API token found, failing")
             return None
@@ -20,18 +68,31 @@ def get_irssi_user(params):
         logging.warning('No user found with the api token!')
         return None
 
-    logging.debug("Google user found")
+    # try using oauth login from session info
+    try:
+        idToken = session['id_token'] # jwt token from openid
+        logging.debug(f"Access token {idToken}")
 
-    user_id = user.user_id()
-    if user_id is None:
-        federated_identity = "%s%s" % (user.federated_provider(), user.federated_identity())
-        logging.warn("Strange, using federated identity %s" % federated_identity)
-        user_id = federated_identity
+        client_id = secret_manager.get_secret("oauth2-client-id")
 
-    irssi_user = dao.get_irssi_user_for_key_name(user_id)
-    if irssi_user is None:
-        logging.debug("IrssiUser not found, adding new one")
-        irssi_user = dao.add_irssi_user(user, user_id)
+        # Verify the ID token
+        id_info = id_token.verify_oauth2_token(idToken, authrequests.Request(), client_id)
+        logging.debug(f"Id_info: {id_info}")
 
-    logging.debug('authorized as %s (%s)' % (irssi_user.user_name, irssi_user.email))
-    return irssi_user
+        # ID token is valid, get user info
+        user_id = id_info.get('sub')
+        email = id_info.get('email')
+        logging.debug(f"Got google login: {email}")
+
+        irssi_user = dao.get_irssi_user_for_key_name(user_id, email)
+        if irssi_user is None:
+            logging.debug("IrssiUser not found, adding new one")
+            irssi_user = dao.add_irssi_user(email, user_id)
+
+        logging.debug(f"authorized as {irssi_user.user_name} ({irssi_user.email})")
+        return irssi_user
+
+    except ValueError as e:
+        logging.warning(f'Invalid ID token! Error {e}')
+        return None
+

--- a/Server/IrssiNotifierServer/main.py
+++ b/Server/IrssiNotifierServer/main.py
@@ -1,28 +1,57 @@
-import webapp2
+from flask import Flask, request
 import logging
-import emaillogginghandler
 from controllers import *
+import secret_manager
 
+app = Flask(__name__)
+app.secret_key = secret_manager.get_secret('flask-secret')
+logging.basicConfig(level=logging.DEBUG)
 
-def handle_404(request, response, exception):
-    logging.warn("404'd")
-    response.write("lol 404'd")
-    response.set_status(404)
+@app.errorhandler(404)
+def handle_404(error):
+    logging.warning(f"404'd, error: {error}")
+    return "lol 404'd", 404
 
+@app.route('/oauth2callback')
+def oauth2callback():
+    return login.oauth2callback()
 
-app = webapp2.WSGIApplication(
-    [('/', WebController),
-     ('/API/Settings', SettingsController),
-     ('/API/Message', MessageController),
-     ('/API/Command', CommandController),
-     ('/API/Wipe', WipeController),
-     ('/API/Nonce', NonceController),
-     ('/API/License', LicensingController),
-     ('/admin', AdminController),
-     ('/analytics', AnalyticsController)],
-    debug=True)
+@app.route('/logout')
+def logout():
+    return login.logout();
 
-app.error_handlers[404] = handle_404
+@app.route('/')
+def web_controller():
+    return WebController().get()
 
-logging.debug("loaded main")
-emaillogginghandler.register_logger(["irssinotifier@gmail.com"])
+@app.route('/API/Settings', methods=['GET', 'POST'])
+def settings_controller():
+    return SettingsController().get() if request.method == 'GET' else SettingsController().post()
+
+@app.route('/API/Message', methods=['GET', 'POST'])
+def message_controller():
+    return MessageController().get() if request.method == 'GET' else MessageController().post()
+
+@app.route('/API/DeferredMessage', methods=['GET', 'POST'])
+def deferred_message_controller():
+    return DeferredMessageController().get() if request.method == 'GET' else DeferredMessageController().post()
+
+@app.route('/API/Command', methods=['GET', 'POST'])
+def command_controller():
+    return CommandController().get() if request.method == 'GET' else CommandController().post()
+
+@app.route('/API/Wipe', methods=['GET', 'POST'])
+def wipe_controller():
+    return WipeController().get() if request.method == 'GET' else WipeController().post()
+
+@app.route('/API/Nonce', methods=['GET', 'POST'])
+def nonce_controller():
+    return NonceController().get() if request.method == 'GET' else NonceController().post()
+
+@app.route('/API/License', methods=['GET', 'POST'])
+def licensing_controller():
+    return LicensingController().get() if request.method == 'GET' else LicensingController().post()
+
+if __name__ == '__main__':
+    logging.debug("loaded main")
+    app.run(debug=True)

--- a/Server/IrssiNotifierServer/requirements.txt
+++ b/Server/IrssiNotifierServer/requirements.txt
@@ -1,0 +1,13 @@
+google-cloud-ndb
+google-cloud-secret-manager
+#google-cloud-memcache
+google-auth
+google-auth-oauthlib
+google-auth-httplib2
+flask
+flask-cors
+requests
+firebase-admin
+pycryptodome
+google-cloud-tasks
+gunicorn

--- a/Server/IrssiNotifierServer/secret_manager.py
+++ b/Server/IrssiNotifierServer/secret_manager.py
@@ -1,0 +1,38 @@
+import logging
+import os
+#from google.cloud import memcache_v1beta2 as memcache
+from google.cloud import secretmanager
+
+# Initialize Secret Manager client
+secret_client = secretmanager.SecretManagerServiceClient()
+
+# Initialize Memcache client
+#memcache_client = memcache.CloudMemcacheClient()
+
+# Use environment variables for project ID and location
+PROJECT_ID = os.getenv('PROJECT_ID')
+LOCATION = os.getenv('LOCATION', 'default_location')
+
+#def get_memcache_value(key):
+#    try:
+#        response = memcache_client.get_instance(name=f"projects/{PROJECT_ID}/locations/{LOCATION}/instances/YOUR_INSTANCE_ID")
+#        return response.get(key)
+#    except Exception as e:
+#        logging.error("Unable to get memcache value for key %s: %s" % (key, str(e)))
+#        return None
+
+#def set_memcache_value(key, value):
+#    try:
+#        response = memcache_client.get_instance(name=f"projects/{PROJECT_ID}/locations/{LOCATION}/instances/YOUR_INSTANCE_ID")
+#        response.set(key, value)
+#    except Exception as e:
+#        logging.error("Unable to set memcache value for key %s: %s" % (key, str(e)))
+
+def get_secret(secret_name):
+    try:
+        name = f"projects/{PROJECT_ID}/secrets/{secret_name}/versions/latest"
+        response = secret_client.access_secret_version(name=name)
+        return response.payload.data.decode('UTF-8')
+    except Exception as e:
+        logging.error("Unable to read secret %s: %s" % (secret_name, str(e)))
+    return None

--- a/Server/IrssiNotifierServer/static/style.css
+++ b/Server/IrssiNotifierServer/static/style.css
@@ -140,10 +140,6 @@ img.center {
 	width: 200px;
 }
 
-.googleplus {
-	margin-top: 25px;
-}
-
 .news {
 	color: #fefefe;
 	margin-top: 65px;

--- a/Server/IrssiNotifierServer/templates/html/index.html
+++ b/Server/IrssiNotifierServer/templates/html/index.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html>
+
+<!-- IrssiNotifier, last updated 2016-03-26 -->
+
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <link rel="stylesheet" type="text/css" href="static/style.css" />
+    <link rel="icon" type="image/png" href="static/icon.png" />
+    <link rel="canonical" href="https://irssinotifier.appspot.com" />
+
+    <title>IrssiNotifier</title>
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+
+    <script type="text/javascript">
+        var currentView = "";
+        var lock = false;
+
+        function switchView(button, view) {
+            if (lock) return;
+            $(".navi-selected").removeClass('navi-selected');
+
+            if (button != null) {
+                $(button).addClass('navi-selected');
+            }
+
+            if (view == currentView) return;
+
+            if (currentView == "") {
+                $(view).fadeIn();
+            } else {
+                lock = true;
+                $(currentView).fadeOut(function() { lock = false; $(view).fadeIn(); });
+            }
+
+            currentView = view;
+        }
+
+        function hashChanged() {
+            var hash = window.location.hash.substring(1);
+
+            if (hash == "new") switchView(".navi-new", "#content-new");
+            else if (hash == "help") switchView(".navi-help", "#content-help");
+            else if (hash == "profile") switchView(".navi-profile", "#content-profile");
+            else if (hash == "privacy") switchView(null, "#content-privacy");
+            else switchView(".navi-main", "#content-main");
+        }
+
+        $(function() {
+            replaceDateTimes();
+
+            $(".navi-main").click(function()     { parent.location.hash = "main"; hashChanged(); });
+            $(".navi-new").click(function()     { parent.location.hash = "new"; hashChanged(); });
+            $(".navi-help").click(function()     { parent.location.hash = "help"; hashChanged(); });
+            $(".navi-profile").click(function() { parent.location.hash = "profile"; hashChanged(); });
+            $(".banner").click(function() { $(".navi-main").click(); });
+
+            $(window).bind('hashchange', hashChanged);
+            hashChanged();
+        });
+
+        function wipe() {
+            var answer = confirm("Wipe all user data?");
+            if (answer) {
+                $.post("/API/Wipe", { }, function(data) {
+                    window.location.replace('{{ logout_url }}');
+                });
+            }
+        }
+
+        function update(checkbox, name, token) {
+            var enabled = checkbox.checked ? 1 : 0;
+            $.post("/API/Settings", { "Name": name, "RegistrationId": token, "Enabled": enabled }, function(data) {
+                alert("Device " + name + (checkbox.checked ? " enabled." : " disabled."));
+            });
+        }
+
+        function remove_device(name, token) {
+            var answer = confirm("Remove device " + name + "?");
+            if (answer) {
+                $.post("/API/Wipe", { "RegistrationId": token }, function(data) {
+                    location.reload();
+                });
+            }
+        }
+
+        function replaceDateTimes() {
+            $(".datetime").each(function(index, element) {
+                var text = $(element).html();
+                if (!isNaN(text)) {
+                    var utcSeconds = text;
+                    var epoch = new Date(0);
+                    epoch.setUTCSeconds(utcSeconds);
+
+                    $(element).html(epoch.toLocaleString());
+                }
+            });
+        }
+    </script>
+
+</head>
+<body>
+    <a href="https://github.com/murgo/irssinotifier"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+    <div class="box">
+
+{% if license_type == 'Plus' %}
+    <img class="center banner" src="static/banner_plus.png" alt="IrssiNotifier" />
+{% else %}
+    <img class="center banner" src="static/banner.png" alt="IrssiNotifier" />
+{% endif %}
+    <div id="navi" class="center">
+        <div class="navibutton navi-main"><a href="#main">Main</a></div>
+        <div class="navibutton navi-new"><a href="#new">What's new</a></div>
+        <div class="navibutton navi-help"><a href="#help">Help</a></div>
+        <div class="navibutton navi-profile"><a href="#profile">My profile</a></div>
+    </div>
+
+    <div id="content-main" class="hidden content">
+
+        <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier">
+            <img src="static/phone.png" alt="IrssiNotifier screenshot" style="float:right;" />
+        </a>
+
+        <h1>IrssiNotifier</h1>
+
+        <div class="google-play">
+            <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier">
+                <img alt="Android app on Google Play" src="//play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+            </a>
+        </div>
+
+        <h2>IrssiNotifier+</h2>
+
+        <div class="google-play">
+            <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier.plus">
+                <img alt="Android app on Google Play" src="//play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+            </a>
+        </div>
+
+        <br >
+
+        <div class="questions">
+        <p class="question">What?</p>
+        <p class="answer">
+            Get notifications from IRC hilights and private messages straight to your Android™ device! Project is open source, see <a href="https://github.com/murgo/IrssiNotifier">GitHub project page</a> for details. Check <a href="http://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier">Google Play™</a> for screenshots. There are also unofficial support for <a href="http://www.weechat.org/files/scripts/irssinotifier.py">WeeChat</a> and <a href="https://github.com/evgeni/IrssiNotifier/tree/python/Python">Python</a>.
+        </p>
+
+        <p class="question">How?</p>
+        <p class="answer">
+            IrssiNotifier uses Irssi script to send IRC messages to server, and Google's Cloud to Device Messaging framework to send notifications to Android device. This minimizes the battery usage of your device, and enables notifications to be sent near real time.
+        </p>
+
+        <p class="question">Where?</p>
+        <p class="answer">
+            First download IrssiNotifier Android app from <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier">Google Play</a>. After that, follow instructions about setting up the Irssi script in the <a href="#help">help page</a>.
+        </p>
+
+        <p class="question">What do I need?</p>
+        <p class="answer">
+            You'll need Irssi running on Linux server or similar (with wget installed). You'll also need an Android device (phone or tablet, or both) with Android version 2.2 (froyo) or later.
+        </p>
+
+        <p class="question">Privacy?</p>
+        <p class="answer">
+            All data is end-to-end encrypted with the encryption password of your choice. Password is never sent to the server. You'll have to login with your Google account, but no password or other sensitive data is collected. Check <a href="#privacy">privacy page</a> for details.
+        </p>
+
+        <p class="question">Who?</p>
+        <p class="answer">
+            This service was made by Lauri Härsilä, murgo @ IRCnet. If you have any questions, drop me a line by <a href="mailto:murgo@iki.fi">email</a> or join #irssinotifier at IRCnet. Huge thanks to everybody who have donated money or contributed source! Thanks to <a href="http://heidifriman.fi">Heidi Friman</a> for icons.
+        </p>
+
+        <p class="question">How can I help?</p>
+        <p class="answer">
+            IrssiNotifier was created entirely on my free time. If you have found IrssiNotifier useful and want to help keep project alive, please consider buying the <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier.plus">IrssiNotifier+</a> and/or donating through PayPal or Flattr.
+        </p>
+
+        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" style="float:left">
+            <input type="hidden" name="cmd" value="_s-xclick">
+            <input type="hidden" name="encrypted" value="-----BEGIN PKCS7-----MIIHLwYJKoZIhvcNAQcEoIIHIDCCBxwCAQExggEwMIIBLAIBADCBlDCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb20CAQAwDQYJKoZIhvcNAQEBBQAEgYBfZTQp/7MC5zqHtYv4QXSuKoL0W2F2XmoJCB5mb8SnqZZXYQQppoxBJRKjnBP6XPlX8VMHQCgCFFftIY2fdoFfpr2ZBhf9sQct9M4SQLZPnQKdKsZuUAiQujks+VESSX+qCxMBIxD/Bwi+N6O3Pno6f+bJZqf4cHfYUGORQdGt3zELMAkGBSsOAwIaBQAwgawGCSqGSIb3DQEHATAUBggqhkiG9w0DBwQIb/wPbS23b6eAgYhwsVWGID9q5QvVULDqqJwy35GxjJaBiKWUo4XBi+L68hhjjdUS4g3w667RoWYOve9BiiIqS9LY9Zifw8g+3u3h07n3PHfoR3lXHJyrsBOdgLVImhy1nqogS6SN5+gEYdqNF+8Vto1KKOm8Lyx8qjX0mkfqeMVqQI3T9LZRUtjxh4s1E1t9FstNoIIDhzCCA4MwggLsoAMCAQICAQAwDQYJKoZIhvcNAQEFBQAwgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMB4XDTA0MDIxMzEwMTMxNVoXDTM1MDIxMzEwMTMxNVowgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBR07d/ETMS1ycjtkpkvjXZe9k+6CieLuLsPumsJ7QC1odNz3sJiCbs2wC0nLE0uLGaEtXynIgRqIddYCHx88pb5HTXv4SZeuv0Rqq4+axW9PLAAATU8w04qqjaSXgbGLP3NmohqM6bV9kZZwZLR/klDaQGo1u9uDb9lr4Yn+rBQIDAQABo4HuMIHrMB0GA1UdDgQWBBSWn3y7xm8XvVk/UtcKG+wQ1mSUazCBuwYDVR0jBIGzMIGwgBSWn3y7xm8XvVk/UtcKG+wQ1mSUa6GBlKSBkTCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb22CAQAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQCBXzpWmoBa5e9fo6ujionW1hUhPkOBakTr3YCDjbYfvJEiv/2P+IobhOGJr85+XHhN0v4gUkEDI8r2/rNk1m0GA8HKddvTjyGw/XqXa+LSTlDYkqI8OwR8GEYj4efEtcRpRYBxV8KxAW93YDWzFGvruKnnLbDAF6VR5w/cCMn5hzGCAZowggGWAgEBMIGUMIGOMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxFDASBgNVBAoTC1BheVBhbCBJbmMuMRMwEQYDVQQLFApsaXZlX2NlcnRzMREwDwYDVQQDFAhsaXZlX2FwaTEcMBoGCSqGSIb3DQEJARYNcmVAcGF5cGFsLmNvbQIBADAJBgUrDgMCGgUAoF0wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTIwMzE5MTgyODE0WjAjBgkqhkiG9w0BCQQxFgQUV/6QbGgh84g47qvrcq8yAl31UhwwDQYJKoZIhvcNAQEBBQAEgYAkKg8df7hiREToT8563ZSbKztgAgmGk9jqVpGyUh5Td0OFXlelsuIencKGyKKZDDqDUYMT+1bIhM99o1FcfwtKm2Ev78cwC5GYFy3HjmAbavos+lGWsZEPGLpglgjfhKwY4NpclXaF5jf7DTtnY2g6R4lQrxjaGXnlS+T2ixtELA==-----END PKCS7-----">
+            <input type="image" src="//www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+            <img alt="" border="0" src="//www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+        </form>
+
+        </div>
+
+    </div>
+
+    <div class="hidden content" id="content-new">
+
+        <h1>What's new?</h1>
+
+        <p class="answer">For latest developments, check project's <a href="https://github.com/murgo/irssinotifier">Github page</a>.<p>
+
+        <p class="question news">17.9.2024: IrssiNotifier broke! :(</p>
+        <div class="answer news-content">
+            Due to recent API deprecation in Firebase Cloud Messaging, IrssiNotifier is currently not delivering messages. To fix this the server needs pretty major rewrite. Sorry for the inconvenience, service will get back up hopefully soon enough.
+            <br /> <br />
+            Thank you for your patience, IRC peeps.
+        </div>
+
+        <p class="question news">2.12.2018: IrssiNotifier 1.9.2 released.</p>
+        <div class="answer news-content">
+            New version of the app has been released, that fixes only single message showing up in the app. Thanks to everybody for reporting, and special thanks to <a href="https://github.com/jheidel">jheidel</a> for debugging the issue.
+        </div>
+
+        <p class="question news">11.11.2018: Android 9 is now supported.</p>
+        <div class="answer news-content">
+            New version of the IrssiNotifier app (1.9.1) has been released, which removes Google Cloud Messaging in favor of Firebase Cloud Messaging to properly support Android Pie.
+            <br /> <br />
+            Also new version (24) of Irssi script has been released with the following features:
+            <ul>
+                <li>OpenSSL warnings are dismissed to get rid of AES-128 deprecation warnings of new OpenSSL. Probably not best practice. Feel free to fix properly and send PR.</li>
+                <li>New option: irssinotifier_required_channel_patterns can be used to whitelist channels (thanks <a href="https://github.com/smith153">smith153</a>)</li>
+                <li>Improved Screen detection, some environments display screen socket differently thus breaking screen attach state detection (thanks <a href="https://github.com/benedicteb">benedicteb</a>) </li>
+            </ul>
+        </div>
+
+        <p class="question news">5.7.2017 Irssi script version 22 released.</p>
+        <div class="answer news-content">
+            New version of OpenSSL is now supported. If you're having encryption troubles, try updating the script.
+        </div>
+
+        <p class="question news">21.2.2016 Server version 9 released.</p>
+        <div class="answer news-content">
+            Messages should now wake up Android 6.0 correctly. Thanks, <a href="https://github.com/scolphoy">scolphoy</a>, for the pull request.
+        </div>
+
+        <p class="question news">8.4.2014 Irssi script 20 released.</p>
+        <div class="answer news-content">
+            The previously broken script is now (hopefully) fixed. If you installed script version 19 in the last couple of days, you might need to restart your Irssi or run following commands in Irssi after updating the script:
+            <div class="code-block">
+            /script exec $SIG{CHLD} = 'IGNORE';
+            <br />
+            /script exec wait;
+            </div>
+            Run the last line each for every zombie process you might have. Check earlier news post for more details. Please contact me if you are having issues. 
+        </div>
+
+        <p class="question news">7.4.2014 Rollback of Irssi script 19.</p>
+        <div class="answer news-content">
+            There's some issues with the latest release of the IrssiNotifier Irssi script, so it's been reverted until we get it fixed. Techinal jargon: broken script spawned a defunct zombie process for each highlight. If you have lots of Irssi zombie processes (ps x), run "/script exec wait;" in the Irssi. You have to run this one for each zombie process.
+            <br/> <br/>
+            Sorry!
+        </div>
+
+        <p class="question news">4.4.2014 Irssi script 19 released!</p>
+        <div class="answer news-content">
+            Welp, it's been almost a year! Here's new script, thanks to people who fixed my stuff! Fixes and features:
+            <ul>
+                <li>Support for <a href="http://tmux.sourceforge.net/">tmux</a>! tmux attach/detach state is used through the /set irssinotifier_screen_detached_only. Thanks to <a href="https://github.com/mlb-">mlb-</a> and <a href="https://github.com/vanaltj">vanaltj</a> for this.</li>
+                <li>"Queue is full" error message should be fixed now, thanks <a href="https://github.com/qvr">qvr</a>!</li>
+                <li>Couple of miscellaneous bug fixes.</li>
+            </ul>
+        </div>
+
+        <p class="question news">2.6.2013 IrssiNotifier/IrssiNotifier+ 1.7 with Irssi script 18 released!</p>
+        <div class="answer news-content">
+            New script option: irssinotifier_clear_notifications_when_viewed.
+            When this command is turned on, notifications on the phone are cleared automatically when you change away from the last window that had hilights.
+            <br /> <br />
+            Pretty handy! Thanks to <a href="https://github.com/qvr">qvr</a> for implementing this!
+        </div>
+
+        <p class="question news">28.5.2013 IrssiNotifier/IrssiNotifier+ 1.6.13 released!</p>
+        <div class="answer news-content">
+            App should no longer forget old messages when receiving new ones. Sorry about that, thanks for everybody who reported the bug.
+        </div>
+
+        <p class="question news">24.5.2013 IrssiNotifier/IrssiNotifier+ 1.6.12 released!</p>
+        <div class="answer news-content">
+            Yesterday's release contained couple of critical bugs that are now fixed:
+            <ul>
+                <li>Fixed app not working at all on Android 2.x</li>
+                <li>IrssiNotifier+: Fixed error preventing licensing and app from starting</li>
+            </ul>
+        </div>
+
+        <p class="question news">23.5.2013 IrssiNotifier 1.6 and IrssiNotifier+ released!</p>
+        <div class="answer news-content">
+            New version contains following improvements:
+            <ul>
+                <li>Fixed bug where account needed to be re-selected every now and then</li>
+                <li>Offline-mode. Simply disable notifications from the settings, and app is completely offline, no background data is being used</li>
+                <li>You can now choose notification LED color</li>
+                <li>Sound is now played even if the app is on top when new notification arrives</li>
+                <li>Fixed changing of Google accounts</li>
+                <li>Feed and channels now have date headers for increased readability, thanks <a href="https://github.com/qvr">qvr</a>!</li>
+                <li>Improved performance</li>
+                <li>Fixed notifications on Android 3.2</li>
+                <li>Channel names are no longer case sensitive</li>
+                <li>Lots of small bug fixes</li>
+            </ul>
+            Also, IrssiNotifier+ has been released. In addition to the above fixes, IrssiNotifier+ has the ability to pull the messages from the server on app startup, so you'll receive messages even if they don't get pushed through! This is useful when you are not online all the time, or if you have notifications disabled. You can support development of IrssiNotifier by buying it from <a href="https://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier.plus">Google Play</a>. Thank you for your support.
+        </div>
+
+        <p class="question news">23.5.2013 Irssi script version 17 released</p>
+        <div class="answer news-content">
+            Irssi script now disregards idle timeout if you are not attached to your Screen, so you'll get notifications straight away after detaching. Also, the script should no longer send garbled notifications when using Twirssi or other 3rd party addon. Check the updated <a href="#help">upgrade instructions</a>.
+        </div>
+
+        <p class="question news">5.4.2013 Server software updated</p>
+        <div class="answer news-content">
+            New server software is up! Lots of changes and bugfixes under the hood (improved perfomance, improved error handling etc.). Also, now you can remove devices from the <a href="#profile">profile page</a> in addition to disabling them.
+            <br /> <br />
+            As usual, if you run into some glitches or other oddities, please inform me through IRC or mail.
+        </div>
+
+        <p class="question news">2.4.2013 Irssi script version 15 released</p>
+        <div class="answer news-content">
+            I slightly botched up the version 14 release, so version 15 contains some hotfixes.
+        </div>
+
+        <p class="question news">1.4.2013 Irssi script version 14 released</p>
+        <div class="answer news-content">
+            No, this is not an April Fools joke, I am actually releasing something. Lots of fixes and new features for the script, thanks to many people who have sent pull requests to me! Just follow the two simple steps on top of <a href="#help">help page</a> to update.
+            <br /><br />
+            New features and fixes:
+            <ul>
+                <li>Added optional support for DCC chats</li>
+                <li>Added support for /hilight -level JOINS somebody</li>
+                <li>Added support for non-UTF-8 encodings. Thanks, <a href="https://github.com/qvr">qvr</a>!</li>
+                <li>Added built-in <a href="http://en.wikipedia.org/wiki/GNU_Screen">Screen</a> integration. Thanks, <a href="https://github.com/qvr">qvr</a>!</li>
+                <li>Sending notifications should no longer freeze Irssi for a sec. Thanks, <a href="https://github.com/qvr">qvr</a>!</li>
+                <li>Added support for nick blacklisting. Thanks, <a href="https://github.com/turmoni">turmoni</a>!</li>
+                <li>Added support for pattern blacklisting. Thanks, <a href="https://github.com/turmoni">turmoni</a>!</li>
+                <li>Added support for pattern whitelisting. Thanks, <a href="https://github.com/turmoni">turmoni</a>!</li>
+                <li>Added support for https-proxy. Thanks, <a href="https://github.com/rsdy">rsdy</a>!</li>
+                <li>Fixed rarely occurring bug with encryption (reading environment variables didn't work on all systems)</li>
+            </ul>
+            <br />
+            Following new commands have been added, check <a href="#help">help page</a> for more details:
+            <ul>
+                <li>irssinotifier_enable_dcc</li>
+                <li>irssinotifier_https_proxy</li>
+                <li>irssinotifier_ignored_nicks</li>
+                <li>irssinotifier_ignored_highlight_patterns</li>
+                <li>irssinotifier_required_public_highlight_patterns</li>
+                <li>irssinotifier_screen_detached_only</li>
+            </ul>
+        </div>
+
+        <p class="question news">27.10.2012 Irssi script version 13 released</p>
+        <div class="answer news-content">
+            Yesterday's <a href="http://googleappengine.blogspot.fi/2012/10/about-todays-app-engine-outage.html">Google App Engine blackout</a> caused some IrssiNotifier users to receive duplicate messages, Irssi freezes and/or other hassle. Sorry for that!
+            <br /><br />
+            Now, to prevent this from happening in the future, newest Irssi script now times out before freezing up. <a href="#help">Updating</a> is very much recommended.
+        </div>
+
+        <p class="question news">11.10.2012 Irssi script was broken yesterday</p>
+        <div class="answer news-content">
+            I accidentally deployed a broken work-in-progress version of the Irssi script yesterday, so if you installed or updated the script recently and are having problems, please update the script to the latest official version using these <a href="#help">instructions</a>.
+        </div>
+
+        <p class="question news">10.10.2012 IrssiNotifier 1.5 released</p>
+        <div class="answer news-content">
+            New features:
+            <ul>
+                <li>Fixed bug that caused app sometimes to freeze when clearing notifications. Hopefully actually got it this time!</li>
+            </ul>
+        </div>
+
+        <p class="question news">1.10.2012 IrssiNotifier 1.4 released</p>
+        <div class="answer news-content">
+            New features:
+            <ul>
+                <li>Added "legacy"-settings option that disables user interface theme</li>
+                <li>Fixed bug that caused app sometimes to freeze when clearing notifications</li>
+                <li>Fixed bug that caused app to crash when switching notification sound</li>
+                <li>Fixed settings colors behaving strangely on some devices</li>
+            </ul>
+        </div>
+
+        <p class="question news">15.9.2012 Irssi script version 12 released</p>
+        <div class="answer news-content">
+            Fixed small bug with hard coded paths, if your Irssi complains about "cannot find wget" or OpenSSL, try updating the script.
+        </div>
+
+        <p class="question news">12.9.2012 IrssiNotifier 1.3 released!</p>
+        <div class="answer news-content">
+            This is a major release. Older versions of Android app won't work any more, since server side has been changed a lot.
+            <br /> <br />
+            New features:
+            <ul>
+                <li>New UI! Colors! Yay!</li>
+                <li>Jelly Bean (Android 4.1) expandable notifications!</li>
+                <li>Irssi ConnectBot host can now be picked in settings</li>
+                <li>Improved tablet layout</li>
+                <li>Improved web page with additional statistics</li>
+                <li>Migration from C2DM to GCM</li>
+                <li>Threaded server should provide more performance</li>
+                <li>Added <a href="#privacy">privacy policy</a></li>
+            </ul>
+
+            <br />
+            Bug fixes:
+            <ul>
+                <li>Account selection screen no longer should appear after registering</li>
+                <li>ICB icon shows up in correct size with Jelly Bean</li>
+                <li>Miscellaneous crash fixes</li>
+                <li>Android registration shouldn't get added many times when uninstalling and reinstalling</li>
+                <li>Improved tablet layout</li>
+            </ul>
+
+            Whew!
+        </div>
+
+        <p class="question news">12.9.2012 New version of Irssi script: 11.</p>
+        <div class="answer news-content">
+            Fixed bug where Irssi script sometimes caused other scripts like mail.pl to crash.
+        </div>
+
+        <p class="question news">6.9.2012 New web page!</p>
+        <div class="answer news-content">
+            New web page layout! Feedback is welcomed. Enjoy.
+        </div>
+
+        <p class="question news">6.9.2012 New version of Irssi script: 9.</p>
+        <div class="answer news-content">
+            New version of Irssi script is released! The script is nearly completely re-written.
+            New features include new commands such as
+            <div class="code-block">/set irssinotifier_ignored_channels [channel names]</div>
+            and
+            <div class="code-block">/set irssinotifier_ignored_servers [server names]</div>
+            Release also contain bugfixes like stripping broken color codes from notifications and various small other things. Check the <a href="#help">help page</a> for upgrade instructions.
+        </div>
+    </div>
+
+    <div class="hidden content" id="content-help">
+
+        <h1>Help!</h1>
+
+{% if irssi_working %}
+
+        <h2>Irssi script upgrade instructions</h2>
+
+        <div class="answer">
+            Don't worry, your settings won't get lost.<br >
+            <ol>
+                <li>Download Irssi script by copying and pasting the following command (as a single line) to your shell (don't mind any "File exists" -errors):
+                    <div class="code-block">mkdir -p ~/.irssi/scripts/autorun; wget --no-check-certificate https://irssinotifier.appspot.com/script/irssinotifier.pl -O ~/.irssi/scripts/irssinotifier.pl; ln -s ~/.irssi/scripts/irssinotifier.pl ~/.irssi/scripts/autorun/irssinotifier.pl</div>
+                </li>
+                <li>Reload Irssi script by typing the following command to Irssi:
+                    <div class="code-block">/script load irssinotifier</div>
+                </li>
+            </ol>
+        </div>
+
+{% endif %}
+
+        <h2>Irssi script installation instructions</h2>
+
+        <div class="answer">
+        (To upgrade script, just follow steps 1 and 2). Script depends on wget and openssl.
+        <ol>
+            <li>Download Irssi script by copying and pasting the following command (as a single line) to your shell (don't mind any "File exists" -errors):
+            <div class="code-block">mkdir -p ~/.irssi/scripts/autorun; wget --no-check-certificate https://irssinotifier.appspot.com/script/irssinotifier.pl -O ~/.irssi/scripts/irssinotifier.pl; ln -s ~/.irssi/scripts/irssinotifier.pl ~/.irssi/scripts/autorun/irssinotifier.pl</div>
+            </li>
+            <li>Load Irssi script by typing the following command to Irssi:
+            <div class="code-block">/script load irssinotifier</div>
+            </li>
+            <li>Set api token in Irssi
+            <div class="code-block">{% if logged_in %}/set irssinotifier_api_token {{ user.api_token }}{% else %}<a href="{{ login_url }}">Log in to see instructions</a>{% endif %}</div>
+            </li>
+            <li>Optional: Change your encryption password with the following command. You'll have to change the password to the Android device, too. Password can be anything you like (forbidden characters: ", \, `). Do not use your Google account password (or any other existing password) for security reasons.
+            <div class="code-block">/set irssinotifier_encryption_password password</div>
+            </li>
+            <li>Ask someone to hilight you or send yourself a private message and check <a href="#profile">profile page</a> to see if it works.</li>
+        </ol>
+        </div>
+
+        <h2>Android app installation instructions</h2>
+
+        <div class="answer">
+        <ol>
+            <li>Download Android app from <a href="http://play.google.com/store/apps/details?id=fi.iki.murgo.irssinotifier">Google Play</a> store.</li>
+            <li>Run the app, select the Google account you want to use. Account must be the same as the one you signed to this website with.</li>
+            <li>Go to settings and set your encryption password. Encryption password must be the same as the one you've set in Irssi script.</li>
+        </ol>
+        </div>
+
+        <h2>Additional Irssi commands</h2>
+        <div id="commands">
+            <p class="answer">You can clear any of these settings by using the following command:</p>
+            <div class="code-block">/set -clear [setting]</div>
+
+            <p class="question">Do not notify while using Irssi</p>
+            <div class="code-block">/set irssinotifier_require_idle_seconds [second count]</div>
+            <p class="answer">When set to more than 0, you will not be notified from events that occur between going idle (i.e. not pressing any keys) and the set second count after that.</p>
+
+            <p class="question">Only receive notifications while away</p>
+            <div class="code-block">/set irssinotifier_away_only [ON or OFF]</div>
+            <p class="answer">When set to ON, notifications will only be sent if you are away. Useful in combination with <a href="http://scripts.irssi.org/scripts/screen_away.pl">screen_away script</a>.
+
+            <p class="question">Don't receive notifications if attached to screen or tmux</p>
+            <div class="code-block">/set irssinotifier_screen_detached_only [ON or OFF]</div>
+            <p class="answer">If on, you don't get notifications when you are attached to the screen or tmux in which Irssi is running.</p>
+
+            <p class="question">Don't receive notifications from currently open window</p>
+            <div class="code-block">/set irssinotifier_ignore_active_window [ON or OFF]</div>
+            <p class="answer">When set to ON, notifications will NOT be sent from the Irssi window currently open. Be aware that if you forget window open while detaching your screen, you will not get notifications from that channel.</p>
+
+            <p class="question">Don't receive notifications from certain channels</p>
+            <div class="code-block">/set irssinotifier_ignored_channels [channel names]</div>
+            <p class="answer">When one or more channels are set, you will not be notified about hilights from those channels. You can also block query windows (private messages) with this command. Use space as a separator (e.g. /set irssinotifier_ignored_channels #channel query).</p>
+
+            <p class="question">Don't receive notifications from certain servers</p>
+            <div class="code-block">/set irssinotifier_ignored_servers [server names]</div>
+            <p class="answer">When one or more servers are set, you will not be notified about hilights from those servers. Useful for blocking bitlbee etc. Use space as a separator (e.g. /set irssinotifier_ignored_servers IRCnet quakenet).</p>
+
+            <p class="question">Don't receive notifications from certain nicks</p>
+            <div class="code-block">/set irssinotifier_ignored_nicks [nicks]</div>
+            <p class="answer">When one or more nicks are set, you will not be notified about hilights from those nicks (users). Use space as a separator (e.g. /set irssinotifier_ignored_nicks mom murgo).</p>
+
+            <p class="question">Don't receive notifications that contain certain patterns (regular expressions)</p>
+            <div class="code-block">/set irssinotifier_ignored_highlight_patterns [patterns]</div>
+            <p class="answer">Notifications about messages that contain the given regex-pattern are not sent. Uses <a href="http://perldoc.perl.org/perlop.html#Regexp-Quote-Like-Operators">perl regex</a>. Use space as a separator (e.g. /set irssinotifier_ignored_highlight_patterns slap [lL][oO]+[lL]).</p>
+
+            <p class="question">Don't receive notifications that DOESN'T contain certain patterns (regular expressions)</p>
+            <div class="code-block">/set irssinotifier_required_public_highlight_patterns [patterns]</div>
+            <p class="answer">Notifications about messages that doesn't contain the given regex-pattern are not sent. Only applies to public messages. Disabled if empty. Uses <a href="http://perldoc.perl.org/perlop.html#Regexp-Quote-Like-Operators">perl regex</a>. Use space as a separator (e.g. /set irssinotifier_required_public_highlight_patterns slap [lL][oO]+[lL]).</p>
+
+            <p class="question">Use proxy for HTTPS</p>
+            <div class="code-block">/set irssinotifier_https_proxy [proxy address]</div>
+            <p class="answer">The given proxy is used for the notification sending. Pretty self-explanatory.</p>
+
+            <p class="question">Enable or disable DCC chats</p>
+            <div class="code-block">/set irssinotifier_enable_dcc [ON or OFF]</div>
+            <p class="answer">If set to OFF, notifications from DCC chats are not sent.</p>
+
+            <p class="question">Automatically clear notifications from phone when they are read</p>
+            <div class="code-block">/set irssinotifier_clear_notifications_when_viewed [ON or OFF]</div>
+            <p class="answer">If set to ON, notifications on the phone are cleared automatically when you change away from the last window that had hilights.</p>
+        </div>
+
+        <h2>Troubleshooting</h2>
+        <div id="troubleshooting">
+            <p class="question">I'm not getting any notifications!</p>
+            <p class="answer">Follow the installation instructions to the letter. Check the <a href="#profile">profile page</a> to see if the installation works (or at least it has been working). Ensure the script is loaded in your Irssi. If you have restored the Android app from backup, clear its data. Notifications might also be blocked by firewall if you use wi-fi. If you need more support, please visit #irssinotifier @ IRCnet or contact me by mail at <a href="mailto:murgo@iki.fi">murgo@iki.fi</a>.</p>
+
+            <p class="question">Notifications work only every now and then!</p>
+            <p class="answer">Every device added to the system has certain limits for the amount of push notifications they can receive (about 20 per hour), which are reset gradually. Use above Irssi commands to reduce amount of wasteful messages sent to you. Furthermore, sometimes Android push notifications have unexpected delays, and some messages may even get lost.</p>
+
+            <p class="question">I'm getting decryption errors on my Android device!</p>
+            <p class="answer">Check that the Android device has the same encryption password as the Irssi script. Instructions to set the Irssi script encryption key are above. On Android, just go to the settings menu.</p>
+
+            <p class="question">Help!</p>
+            <p class="answer">If you need more info, drop by #irssinotifier @ IRCnet or drop me a line at <a href="mailto:murgo@iki.fi">murgo@iki.fi</a>.</p>
+        </div>
+
+    </div>
+
+    <div class="hidden content" id="content-profile">
+
+{% if not logged_in %}
+
+        <p class="center">Please <a href="{{ login_url }}">log in</a> using your Google account.</p>
+
+{% else %}
+
+        <h2>Logged in as {{ user.email }}</h2>
+        <p><a href="{{ logout_url }}">Log out</a>.</p>
+
+        <h2>Your details</h2>
+        <p>Registered on: <span class="datetime">{{ registration_date }}</span></p>
+        <p>API token: {{ user.api_token }}</p>
+{% if license_type == 'Plus' %}
+        <p>License type: <span class="working">{{ license_type }}</span> <span title="License upgrades before 2016-03-26 show the last installation time.">(upgraded on <span class="datetime">{{ license_timestamp }}</span>*)</span></p>
+{% else %}
+        <p>License type: {{ license_type }}</p>
+{% endif %}
+        <p>Notification count (since Plus): {{ notification_count_since_licensed }}</p>
+        <p>Last notification time: <span class="datetime">{{ last_notification_time }}</span></p>
+
+        <h2>Android client status</h2>
+
+{% if token_count != 0 %}
+
+            <p>Android device(s) <span class="working">confirmed as working.</span></p>
+
+            <div id="devices">
+            <h3>Registered devices:</h3>
+            <table>
+                <tr>
+                    <th>Device</th>
+                    <th>Registered</th>
+                    <th>Enabled</th>
+                    <th>Remove</th>
+                </tr>
+{% for token in tokens %}
+                <tr>
+                    <td>{{ token.name }}</td>
+                    <td><span class="datetime">{{ token.registration_date_string }}</span></td>
+                    <td class="center"><input type="checkbox" {% if token.enabled %}checked="checked"{% endif %} onclick="update(this, '{{ token.name }}', '{{ token.gcm_token }}');" /></td>
+                    <td><a href="#" onclick="remove_device('{{ token.name }}', '{{ token.gcm_token }}'); return false;">remove</a></td>
+                </tr>
+{% endfor %}
+            </table>
+            </div>
+
+{% else %}
+            <p>Android device <span class="broken">not confirmed as working.</span></p>
+{% endif %}
+            <h2>Irssi script status</h2>
+
+{% if irssi_working %}
+            <p>Irssi script <span class="working">confirmed as working</span>
+{% if irssi_latest %}
+            and is at <span class="working">latest version</span>.
+{% else %}
+            but is at <span class="oldversion">old version</span>. Check <a href="#help">help page</a> for upgrade instructions.
+{% endif %}
+            </p>
+{% else %}
+            <p>Irssi script <span class="broken">not confirmed as working.</span> Check <a href="#help">help page</a> for installation instructions.</p>
+{% endif %}
+
+        <h2>Operations</h2>
+        <p><a onclick="wipe();" href="javascript:void(0)">Wipe your account and all data!</a></p>
+
+{% endif %}
+
+    </div>
+
+    <div class="hidden content" id="content-privacy">
+
+        <h1>Privacy policy</h1>
+
+        <p>User details are saved in Google App Engine data store. No user passwords (Google password, encryption password etc.) are saved at any time. Following personal information is saved from every user:</p>
+
+        <ul>
+            <li>User name</li>
+            <li>Email address</li>
+            <li>Registration date</li>
+            <li>Total notification count</li>
+            <li>Last notification time</li>
+            <li>Irssi script version</li>
+        </ul>
+
+        <p>Messages are stored in the server for seven days. Messages are encrypted by user's own encryption password (be sure to change yours).</p>
+
+        <p>User can wipe out his/her account from the <a href="#profile">profile page</a>. This will remove all information regarding the user (including messages).</p>
+
+        <p>Anonymous statistics (analytics) will be gathered from users visiting this web site. Anonymous and statistical usage is also collected from Android app users (how many users, from which countries are they from etc.).</p>
+
+    </div>
+
+    </div>
+
+</body>
+</html>
+


### PR DESCRIPTION
Pretty much complete rewrite of whole server to make it work again:

- Updated from Python 2.7 to Python 3.12
- Updated server to support way newer Google App Engine than the legacy it used to
- Use Flask instead of deprecated webapp2
- Use datastore in newer way with ndb
- Use Google Secret Manager instead of having secrets in a file
- Use OAuth2 logins instead of deprecated Users lib
- Use Google Cloud Tasks for deferring/decoupling message sending instead of deprecated Deferred -library
- Use Firebase Cloud Messaging HTTPv1 instead of deprecated legacy one

Untested / not working / commented out:
- Caching (with new memcached)
- Licensing (IrssiNotifier+ might not work correctly)
- Cron job removing old messages

Removed:
- Email logging handler
- Google analytics

Too bad it turns out that SENDER_ID in the Android app is something different than what's in the GCP/Firebase project, thus rewriting the server isn't enough.